### PR TITLE
Add URL configuration where necessary

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -62,6 +62,14 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Guess the public kpi url, assume https
+*/}}
+{{- define "kobo.kpiUrl" -}}
+{{- if .Values.kpi.ingress.enabled }}
+{{- with (first .Values.kpi.ingress.hosts) }}https://{{ .host }}{{- end }}{{- end }}
+{{- end }}
+
+{{/*
 Guess the public kobocat url, assume https
 */}}
 {{- define "kobo.kobocatUrl" -}}

--- a/templates/kobocat/configmap.yaml
+++ b/templates/kobocat/configmap.yaml
@@ -13,8 +13,16 @@ data:
   KOBOCAT_MONGO_USER: {{ required "mongoUser is required" .Values.kobotoolbox.mongoUser }}
   MONGO_USE_TLS: {{ quote .Values.kobotoolbox.mongoTls }}
   DJANGO_LANGUAGE_CODES: {{ quote .Values.kobotoolbox.djangoLanguageCodes }}
+{{- if .Values.kpi.ingress.enabled }}
+  KOBOFORM_URL: {{ include "kobo.kpiUrl" . | quote }}
+{{- end }}
+  KOBOFORM_INTERNAL_URL: http://{{ include "kobo.fullname" . }}-kpi
 {{- if .Values.kobocat.ingress.enabled }}
   KOBOCAT_URL: {{ include "kobo.kobocatUrl" . | quote }}
+{{- end }}
+  KOBOCAT_INTERNAL_URL: http://{{ include "kobo.fullname" . }}-kobocat
+{{- if .Values.enketo.ingress.enabled }}
+  ENKETO_URL: {{ include "kobo.enketoUrl" . | quote }}
 {{- end }}
 {{- range $k, $v := .Values.kobocat.env.normal }}
   {{ $k }}: {{ $v | quote }}

--- a/templates/kpi/configmap.yaml
+++ b/templates/kpi/configmap.yaml
@@ -14,6 +14,10 @@ data:
   KPI_MONGO_USER: {{ required "mongoUser is required" .Values.kobotoolbox.mongoUser }}
   MONGO_USE_TLS: {{ quote .Values.kobotoolbox.mongoTls }}
   DJANGO_LANGUAGE_CODES: {{ quote .Values.kobotoolbox.djangoLanguageCodes }}
+{{- if .Values.kpi.ingress.enabled }}
+  KOBOFORM_URL: {{ include "kobo.kpiUrl" . | quote }}
+{{- end }}
+  KOBOFORM_INTERNAL_URL: http://{{ include "kobo.fullname" . }}-kpi
 {{- if .Values.kobocat.ingress.enabled }}
   KOBOCAT_URL: {{ include "kobo.kobocatUrl" . | quote }}
 {{- end }}


### PR DESCRIPTION
Should fix an issue with paired data URLs looking like `'http://kpi/api/v2/assets/aos4BeMbUtEcFWaXxpkqyF/paired-data/pdGdgvjyhH8Tg3L8CAzzbhf/external.xml'` (and likely other issues)