### PR TITLE
Fix ENKETO integer values parsed as scientific notations

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -191,7 +191,7 @@ enketo:
       # -- Payload limit
       ENKETO_PAYLOAD_LIMIT: 1mb
       # -- Text field character limit
-      ENKETO_TEXT_FIELD_CHARACTER_LIMIT: 1000000
+      ENKETO_TEXT_FIELD_CHARACTER_LIMIT: "1000000"
       # -- Widgets list. It is an array.
       ENKETO_WIDGETS_0: note
       ENKETO_WIDGETS_1: select-desktop


### PR DESCRIPTION
I.e.: `100000` -> `1e+06`