### PR TITLE
Add configuration for service account

### DIFF
--- a/templates/kobocat/configmap.yaml
+++ b/templates/kobocat/configmap.yaml
@@ -18,6 +18,7 @@ data:
   KOBOCAT_URL: {{ include "kobo.kobocatUrl" . | quote }}
 {{- end }}
   KOBOCAT_INTERNAL_URL: http://{{ include "kobo.fullname" . }}-kobocat
+  SERVICE_ACCOUNT_WHITELISTED_HOSTS: {{ include "kobo.fullname" . }}-kobocat
 {{- if .Values.enketo.ingress.enabled }}
   ENKETO_URL: {{ include "kobo.enketoUrl" . | quote }}
 {{- end }}

--- a/templates/kobocat/secrets.yaml
+++ b/templates/kobocat/secrets.yaml
@@ -10,6 +10,7 @@ data:
   DATABASE_URL: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase | b64enc | quote }}
   MONGO_DB_URL: {{ required "mongoDatabase required" .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
   REDIS_SESSION_URL: {{ required "redisSession required" .Values.kobotoolbox.redisSession | b64enc | quote }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ required "serviceAccountBackend required" .Values.kobotoolbox.serviceAccountBackend | b64enc | quote }}
   ENKETO_API_KEY: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
   # -- Alias for Enketo API key. Still in used but deprecated
   ENKETO_API_TOKEN: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}

--- a/templates/kpi/secrets.yaml
+++ b/templates/kpi/secrets.yaml
@@ -10,6 +10,7 @@ data:
   KC_DATABASE_URL: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase | b64enc | quote }}
   MONGO_DB_URL: {{ required "mongoDatabase required" .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
   REDIS_SESSION_URL: {{ required "redisSession required" .Values.kobotoolbox.redisSession | b64enc | quote }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ required "serviceAccountBackend required" .Values.kobotoolbox.serviceAccountBackend | b64enc | quote }}
   ENKETO_API_KEY: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
   # -- Alias for Enketo API key. Still in used but deprecated
   ENKETO_API_TOKEN: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,7 @@ kobotoolbox:
   mongoDatabase: "mongodb://root:password@mongodb:27017"
   kobocatDatabase: "postgis://postgres:password@postgres-postgresql:5432/postgres"
   redisSession: "redis://:pass@redis-master:6379/1"
+  serviceAccountBackend: "redis://:pass@redis-master:6379/1"
   djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt tr zh-hans"
   enketoApiKey: "change_me_please"
 


### PR DESCRIPTION
See https://github.com/kobotoolbox/kobo-service-account/.

`SERVICE_ACCOUNT_BACKEND_URL` points to a Redis database shared by both kpi and kobocat. `SERVICE_ACCOUNT_WHITELISTED_HOSTS` is for kobocat only; kobocat will allow the service account to authenticate only when it receives requests to this (internal) hostname. It's somewhat confusing in that these aren't remote hosts from kobocat's perspective but rather kobocat's own hostname—similar to Django's `ALLOWED_HOSTS`.