### PR TITLE
Create KPI worker for low priority queue

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/component: kpi-worker-low-priority
     {{- include "kobo.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.kpi.worker.autoscaling.enabled }}
-  replicas: {{ .Values.kpi.worker.replicaCount }}
+  {{- if not .Values.kpi.workerLowPriority.autoscaling.enabled }}
+  replicas: {{ .Values.kpi.workerLowPriority.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -32,7 +32,7 @@ spec:
           image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           resources:
-            {{- toYaml .Values.kpi.worker.resources | nindent 12 }}
+            {{- toYaml .Values.kpi.workerLowPriority.resources | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kpi
@@ -40,15 +40,15 @@ spec:
                 name: {{ include "kobo.fullname" . }}-kpi
           command: ["celery", "-A", "kobo", "worker", "--queues=kpi_low_priority_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--autoscale", "2,2"]
 
-      {{- with .Values.kpi.worker.nodeSelector }}
+      {{- with .Values.kpi.workerLowPriority.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.kpi.worker.affinity }}
+      {{- with .Values.kpi.workerLowPriority.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.kpi.worker.tolerations }}
+      {{- with .Values.kpi.workerLowPriority.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -38,7 +38,7 @@ spec:
                 name: {{ include "kobo.fullname" . }}-kpi
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
-          command: ["celery", "-A", "kobo", "worker", "--queues=kpi_low_priority_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--autoscale", "2,2"]
+          command: ["celery", "-A", "kobo", "worker", "--queues=kpi_low_priority_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--concurrency", "2"]
 
       {{- with .Values.kpi.workerLowPriority.nodeSelector }}
       nodeSelector:

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kobo.fullname" . }}-kpi-worker
+  name: {{ include "kobo.fullname" . }}-kpi-worker-low-priority
   labels:
-    app.kubernetes.io/component: kpi-worker
+    app.kubernetes.io/component: kpi-worker-low-priority
     {{- include "kobo.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.kpi.worker.autoscaling.enabled }}
@@ -11,7 +11,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/component: kpi-worker
+      app.kubernetes.io/component: kpi-worker-low-priority
       {{- include "kobo.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -20,7 +20,7 @@ spec:
         checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
         tag: "{{ .Values.kpi.image.tag }}"
       labels:
-        app.kubernetes.io/component: kpi-worker
+        app.kubernetes.io/component: kpi-worker-low-priority
         {{- include "kobo.selectorLabels" . | nindent 8 }}
     spec:
       securityContext:
@@ -38,7 +38,7 @@ spec:
                 name: {{ include "kobo.fullname" . }}-kpi
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
-          command: ["celery", "-A", "kobo", "worker", "--queues", "kpi_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--autoscale", "2,2"]
+          command: ["celery", "-A", "kobo", "worker", "--queues=kpi_low_priority_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--autoscale", "2,2"]
 
       {{- with .Values.kpi.worker.nodeSelector }}
       nodeSelector:

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -38,7 +38,7 @@ spec:
                 name: {{ include "kobo.fullname" . }}-kpi
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
-          command: ["celery", "-A", "kobo", "worker", "--queues", "kpi_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--autoscale", "2,2"]
+          command: ["celery", "-A", "kobo", "worker", "--queues", "kpi_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--concurrency", "2"]
 
       {{- with .Values.kpi.worker.nodeSelector }}
       nodeSelector:

--- a/templates/kpi/hpa-worker-low-priority.yaml
+++ b/templates/kpi/hpa-worker-low-priority.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.kpi.workerLowPriority.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kobo.fullname" . }}-kpi-worker-low-priority
+  labels:
+    {{- include "kobo.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kobo.fullname" . }}-kpi-worker-low-priority
+  minReplicas: {{ .Values.kpi.workerLowPriority.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.kpi.workerLowPriority.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.kpi.workerLowPriority.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.kpi.workerLowPriority.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.kpi.workerLowPriority.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.kpi.workerLowPriority.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -70,6 +70,21 @@ kpi:
       maxReplicas: 20
       targetCPUUtilizationPercentage: 80
       # targetMemoryUtilizationPercentage: 80
+  workerLowPriority:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 800Mi
+      requests:
+        cpu: 300m
+        memory: 280Mi
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 20
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
   ingress:
     enabled: false
     className: ""


### PR DESCRIPTION
Main worker is consuming only the default queue `kpi_queue`
New worker is consuming only the low priority queue `kpi_low_priority_queue`

Chart version is 2.4.0 . May conflict with #14 