### PR TITLE
Upgrade autoscaling api version to v2

### DIFF
--- a/templates/enketo/hpa.yaml
+++ b/templates/enketo/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enketo.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kobo.fullname" . }}-enketo
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.enketo.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.enketo.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.enketo.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.enketo.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.enketo.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.enketo.autoscaling.targetCPU }}
     {{- end }}
-    {{- if .Values.enketo.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.enketo.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.enketo.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.enketo.autoscaling.targetMemory }}
     {{- end }}
 {{- end }}

--- a/templates/kobocat/hpa-worker.yaml
+++ b/templates/kobocat/hpa-worker.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kobocat.worker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kobo.fullname" . }}-kobocat-worker
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.kobocat.worker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.kobocat.worker.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.kobocat.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.kobocat.worker.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kobocat.worker.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.kobocat.worker.autoscaling.targetCPU }}
     {{- end }}
-    {{- if .Values.kobocat.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.kobocat.worker.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kobocat.worker.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.kobocat.worker.autoscaling.targetMemory }}
     {{- end }}
 {{- end }}

--- a/templates/kobocat/hpa.yaml
+++ b/templates/kobocat/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kobocat.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kobo.fullname" . }}-kobocat
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.kobocat.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.kobocat.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.kobocat.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.kobocat.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kobocat.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.kobocat.autoscaling.targetCPU }}
     {{- end }}
-    {{- if .Values.kobocat.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.kobocat.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kobocat.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.kobocat.autoscaling.targetMemory }}
     {{- end }}
 {{- end }}

--- a/templates/kpi/hpa-worker-low-priority.yaml
+++ b/templates/kpi/hpa-worker-low-priority.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kpi.workerLowPriority.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kobo.fullname" . }}-kpi-worker-low-priority
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.kpi.workerLowPriority.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.kpi.workerLowPriority.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.kpi.workerLowPriority.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.kpi.workerLowPriority.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kpi.workerLowPriority.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.kpi.workerLowPriority.autoscaling.targetCPU }}
     {{- end }}
-    {{- if .Values.kpi.workerLowPriority.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.kpi.workerLowPriority.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kpi.workerLowPriority.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.kpi.workerLowPriority.autoscaling.targetMemory }}
     {{- end }}
 {{- end }}

--- a/templates/kpi/hpa-worker.yaml
+++ b/templates/kpi/hpa-worker.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kpi.worker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kobo.fullname" . }}-kpi-worker
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.kpi.worker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.kpi.worker.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.kpi.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.kpi.worker.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kpi.worker.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.kpi.worker.autoscaling.targetCPU }}
     {{- end }}
-    {{- if .Values.kpi.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.kpi.worker.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kpi.worker.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.kpi.worker.autoscaling.targetMemory }}
     {{- end }}
 {{- end }}

--- a/templates/kpi/hpa.yaml
+++ b/templates/kpi/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kpi.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kobo.fullname" . }}-kpi
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.kpi.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.kpi.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.kpi.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.kpi.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kpi.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.kpi.autoscaling.targetCPU }}
     {{- end }}
-    {{- if .Values.kpi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.kpi.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.kpi.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.kpi.autoscaling.targetMemory }}
     {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -26,8 +26,8 @@ kpi:
     enabled: false
     minReplicas: 2
     maxReplicas: 20
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
+    targetCPU: 80
+    targetMemory: 90
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -68,8 +68,8 @@ kpi:
       enabled: true
       minReplicas: 1
       maxReplicas: 20
-      targetCPUUtilizationPercentage: 80
-      # targetMemoryUtilizationPercentage: 80
+      targetCPU: 80
+      # targetMemory: 80
   workerLowPriority:
     replicaCount: 1
     resources:
@@ -83,8 +83,8 @@ kpi:
       enabled: true
       minReplicas: 1
       maxReplicas: 20
-      targetCPUUtilizationPercentage: 80
-      # targetMemoryUtilizationPercentage: 80
+      targetCPU: 80
+      # targetMemory: 80
   ingress:
     enabled: false
     className: ""
@@ -118,8 +118,8 @@ kobocat:
     enabled: false
     minReplicas: 2
     maxReplicas: 20
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 99
+    targetCPU: 80
+    targetMemory: 99
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -164,8 +164,8 @@ kobocat:
       enabled: false
       minReplicas: 1
       maxReplicas: 20
-      targetCPUUtilizationPercentage: 80
-      # targetMemoryUtilizationPercentage: 80
+      targetCPU: 80
+      # targetMemory: 80
 
     
 
@@ -186,8 +186,8 @@ enketo:
     enabled: false
     minReplicas: 2
     maxReplicas: 20
-    targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 90
+    targetCPU: 80
+    # targetMemory: 90
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
autoscaling v2beta is [marked for removal](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126) in v1.26

This also changes our values to use the bitnami helm chart standards, targetCPU/targetMemory.
