### PR TITLE
Run mongo indexes on init and namespace configmaps

### DIFF
--- a/templates/kobocat/configmap.yaml
+++ b/templates/kobocat/configmap.yaml
@@ -30,7 +30,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kobocat-scripts
+  name: {{ include "kobo.fullname" . }}-kobocat-scripts
   labels:
     {{- include "kobo.labels" . | nindent 4 }}
 data:
@@ -41,7 +41,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-kobocat-conf
+  name: {{ include "kobo.fullname" . }}-nginx-kobocat-conf
   labels:
     component: kobocat
     {{- include "kobo.labels" . | nindent 4 }}

--- a/templates/kobocat/deployment.yaml
+++ b/templates/kobocat/deployment.yaml
@@ -115,7 +115,7 @@ spec:
         emptyDir: {}
       - name: scripts
         configMap:
-          name: kobocat-scripts
+          name: {{ include "kobo.fullname" . }}-kobocat-scripts
           defaultMode: 0777
           items:
           - key: run-uwsgi.sh
@@ -124,4 +124,4 @@ spec:
             path: init.sh
       - name: nginx-conf
         configMap:
-          name: nginx-kobocat-conf
+          name: {{ include "kobo.fullname" . }}-nginx-kobocat-conf

--- a/templates/kpi/configmap.yaml
+++ b/templates/kpi/configmap.yaml
@@ -31,7 +31,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kpi-scripts
+  name: {{ include "kobo.fullname" . }}-kpi-scripts
   labels:
     {{- include "kobo.labels" . | nindent 4 }}
 data:
@@ -41,7 +41,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-kpi-conf
+  name: {{ include "kobo.fullname" . }}-nginx-kpi-conf
   labels:
     component: kpi
     {{- include "kobo.labels" . | nindent 4 }}

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -102,11 +102,11 @@ spec:
         emptyDir: {}
       - name: scripts
         configMap:
-          name: kpi-scripts
+          name: {{ include "kobo.fullname" . }}-kpi-scripts
           defaultMode: 0777
           items:
           - key: run-uwsgi.sh
             path: run-uwsgi.sh
       - name: nginx-conf
         configMap:
-          name: nginx-kpi-conf
+          name: {{ include "kobo.fullname" . }}-nginx-kpi-conf

--- a/values.yaml
+++ b/values.yaml
@@ -285,7 +285,7 @@ enketo:
     #      - chart-example.local
 
 nginx:
-  image: nginx:1.21
+  image: nginx:1.23
 
 # Chart managed mongodb uses replicaset (by default) to enable high availility
 # Kobotoolbox does not have automatic retry logic when the mongodb master changes
@@ -296,6 +296,10 @@ mongodb:
   replicaCount: 3
   pdb:
     create: true
+  initdbScripts:
+    init_01_add_index.js: |
+      db.instances.createIndex( { _userform_id: 1 } )
+      db.instances.createIndex( { _userform_id: 1, _id: -1 } )
   persistence:
     size: 40Gi
   auth:


### PR DESCRIPTION
Fixes #5 running mongo initdb scripts to create expected indexes. Similar to https://github.com/kobotoolbox/kobo-docker/blob/ea8f087bd6806f2e614b271ca161c2e1184529ad/mongo/init_01_add_index.sh

Namespaces config maps so that multiple installs can be deployed in one k8s namespace.