### PR TITLE
Make pre-hooks optional 

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 2.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/kobocat/pre-install-job.yaml
+++ b/templates/kobocat/pre-install-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preInstall.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -12,7 +13,7 @@ metadata:
     checksum/configmap: {{ include (print $.Template.BasePath "/kobocat/configmap.yaml") . | sha256sum }}
     tag: "{{ .Values.kobocat.image.tag }}"
 spec:
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: {{ default 600 .Values.preInstall.activeDeadlineSeconds }}
   template:
     spec:
       restartPolicy: Never
@@ -30,3 +31,4 @@ spec:
           - name: {{ $k }}
             value: {{ $v | quote }}
         {{- end }}
+{{- end }}

--- a/templates/kpi/pre-install-job.yaml
+++ b/templates/kpi/pre-install-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preInstall.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -12,7 +13,7 @@ metadata:
     checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
     tag: "{{ .Values.kpi.image.tag }}"
 spec:
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: {{ default 600 .Values.preInstall.activeDeadlineSeconds }}
   template:
     spec:
       restartPolicy: Never
@@ -32,3 +33,4 @@ spec:
           - name: {{ $k }}
             value: {{ $v | quote }}
         {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,10 @@ kobotoolbox:
   djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt tr zh-hans"
   enketoApiKey: "change_me_please"
 
+preInstall:
+  enabled: true
+  activeDeadlineSeconds: 600
+
 kpi:
   image:
     repository: kobotoolbox/kpi


### PR DESCRIPTION
New `preInstall` section is added to `values.yml`. 
By default pre-hooks are enabled and their timeout is set to 600 seconds. 

Both settings can be overridden in the deployment.

```yaml
preInstall:
  enabled: true
  activeDeadlineSeconds: 600
```