### PR TITLE
Remove need for double entry of passwords for helm managed services

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -84,3 +84,42 @@ Guess the public enketo at url, assume https
 {{- if .Values.enketo.ingress.enabled }}
 {{- with (first .Values.enketo.ingress.hosts) }}https://{{ .host }}{{- end }}{{- end }}
 {{- end }}
+
+{{- define "kobo.postgresql.fullname" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.postgresql.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}-postgresql
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kobo.mongodb.fullname" -}}
+{{- if .Values.mongodb.fullnameOverride -}}
+{{- .Values.mongodb.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.mongodb.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}-mongodb
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "mongodb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kobo.redis.fullname" -}}
+{{- if .Values.redis.fullnameOverride -}}
+{{- .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.redis.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}-redis
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/enketo/deployment.yaml
+++ b/templates/enketo/deployment.yaml
@@ -48,6 +48,22 @@ spec:
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.enketo.resources | nindent 12 }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379
+            - name: ENKETO_REDIS_CACHE_URL 
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-enketo

--- a/templates/kobocat/deployment-beat.yaml
+++ b/templates/kobocat/deployment-beat.yaml
@@ -36,6 +36,44 @@ spec:
             requests:
               cpu: 1m
               memory: 32Mi
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.mongodb.fullname" .) .Values.mongodb.auth.existingSecret }}
+                  key: mongodb-passwords
+            - name: MONGO_DB_URL
+              value: mongodb://root:$(MONGODB_PASSWORD)@{{ (include "kobo.mongodb.fullname" .) }}:27017
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: REDIS_SESSION_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/1
+            - name: SERVICE_ACCOUNT_BACKEND_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/6
+            - name: KOBOCAT_BROKER_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/3
+            - name: CACHE_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/5
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kobocat

--- a/templates/kobocat/deployment-worker.yaml
+++ b/templates/kobocat/deployment-worker.yaml
@@ -33,6 +33,44 @@ spec:
           imagePullPolicy: {{ .Values.kobocat.image.pullPolicy }}
           resources:
             {{- toYaml .Values.kobocat.worker.resources | nindent 12 }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.mongodb.fullname" .) .Values.mongodb.auth.existingSecret }}
+                  key: mongodb-passwords
+            - name: MONGO_DB_URL
+              value: mongodb://root:$(MONGODB_PASSWORD)@{{ (include "kobo.mongodb.fullname" .) }}:27017
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: REDIS_SESSION_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/1
+            - name: SERVICE_ACCOUNT_BACKEND_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/6
+            - name: KOBOCAT_BROKER_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/3
+            - name: CACHE_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/5
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kobocat

--- a/templates/kobocat/deployment.yaml
+++ b/templates/kobocat/deployment.yaml
@@ -49,6 +49,44 @@ spec:
             initialDelaySeconds: 5
           resources:
             {{- toYaml .Values.kobocat.resources | nindent 12 }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.mongodb.fullname" .) .Values.mongodb.auth.existingSecret }}
+                  key: mongodb-passwords
+            - name: MONGO_DB_URL
+              value: mongodb://root:$(MONGODB_PASSWORD)@{{ (include "kobo.mongodb.fullname" .) }}:27017
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: REDIS_SESSION_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/1
+            - name: SERVICE_ACCOUNT_BACKEND_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/6
+            - name: KOBOCAT_BROKER_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/3
+            - name: CACHE_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/5
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kobocat

--- a/templates/kobocat/pre-install-job.yaml
+++ b/templates/kobocat/pre-install-job.yaml
@@ -23,10 +23,20 @@ spec:
         imagePullPolicy: {{ .Values.kobocat.image.pullPolicy }}
         command: ["./manage.py","migrate"]
         env:
-          - name: DATABASE_URL
-            value: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
           - name: DJANGO_SECRET_KEY
             value: {{ required "djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}
+          {{- if .Values.postgresql.enabled }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                key: postgres-password
+          - name: DATABASE_URL
+            value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+          {{- else }}
+          - name: DATABASE_URL
+            value: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
+          {{- end }}
         {{- range $k, $v := .Values.kobocat.env.normal }}
           - name: {{ $k }}
             value: {{ $v | quote }}

--- a/templates/kobocat/secrets.yaml
+++ b/templates/kobocat/secrets.yaml
@@ -7,16 +7,22 @@ metadata:
 type: Opaque
 data:
   DJANGO_SECRET_KEY: {{ required "djangoSecret is required" .Values.kobotoolbox.djangoSecret | b64enc | quote }}
+{{ if .Values.kobotoolbox.kobocatDatabase }}
   DATABASE_URL: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase | b64enc | quote }}
-  MONGO_DB_URL: {{ required "mongoDatabase required" .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
+{{ end }}
+{{ if .Values.kobotoolbox.mongoDatabase }}
+  MONGO_DB_URL: {{ .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
+{{ end }}
 {{ if .Values.kobotoolbox.redis }}
   REDIS_SESSION_URL: {{ printf "%s/1" .Values.kobotoolbox.redis | b64enc | quote }}
   SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6" .Values.kobotoolbox.redis | b64enc | quote }}
   KOBOCAT_BROKER_URL: {{ printf "%s/3" .Values.kobotoolbox.redis | b64enc | quote }}
   CACHE_URL: {{ printf "%s/5" .Values.kobotoolbox.redis | b64enc | quote }}
-{{ else }}
-  REDIS_SESSION_URL: {{ required "redisSession required" .Values.kobotoolbox.redisSession | b64enc | quote }}
-  SERVICE_ACCOUNT_BACKEND_URL: {{ required "serviceAccountBackend required" .Values.kobotoolbox.serviceAccountBackend | b64enc | quote }}
+{{ else if .Values.kobotoolbox.redisSession }}
+  REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
+{{ if .Values.kobotoolbox.serviceAccountBackend }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ .Values.kobotoolbox.serviceAccountBackend | b64enc | quote }}
+{{ end }}
 {{ end }}
   ENKETO_API_KEY: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
   # -- Alias for Enketo API key. Still in used but deprecated

--- a/templates/kpi/deployment-beat.yaml
+++ b/templates/kpi/deployment-beat.yaml
@@ -36,6 +36,46 @@ spec:
             requests:
               cpu: 1m
               memory: 32Mi
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgres://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/koboform
+            - name: KC_DATABASE_URL
+              value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.mongodb.fullname" .) .Values.mongodb.auth.existingSecret }}
+                  key: mongodb-passwords
+            - name: MONGO_DB_URL
+              value: mongodb://root:$(MONGODB_PASSWORD)@{{ (include "kobo.mongodb.fullname" .) }}:27017
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: REDIS_SESSION_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/1
+            - name: SERVICE_ACCOUNT_BACKEND_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/6
+            - name: KPI_BROKER_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/2
+            - name: CACHE_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/4
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kpi

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -33,6 +33,46 @@ spec:
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           resources:
             {{- toYaml .Values.kpi.workerLowPriority.resources | nindent 12 }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgres://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/koboform
+            - name: KC_DATABASE_URL
+              value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.mongodb.fullname" .) .Values.mongodb.auth.existingSecret }}
+                  key: mongodb-passwords
+            - name: MONGO_DB_URL
+              value: mongodb://root:$(MONGODB_PASSWORD)@{{ (include "kobo.mongodb.fullname" .) }}:27017
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: REDIS_SESSION_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/1
+            - name: SERVICE_ACCOUNT_BACKEND_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/6
+            - name: KPI_BROKER_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/2
+            - name: CACHE_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/4
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kpi

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -33,6 +33,46 @@ spec:
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           resources:
             {{- toYaml .Values.kpi.worker.resources | nindent 12 }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgres://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/koboform
+            - name: KC_DATABASE_URL
+              value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.mongodb.fullname" .) .Values.mongodb.auth.existingSecret }}
+                  key: mongodb-passwords
+            - name: MONGO_DB_URL
+              value: mongodb://root:$(MONGODB_PASSWORD)@{{ (include "kobo.mongodb.fullname" .) }}:27017
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: REDIS_SESSION_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/1
+            - name: SERVICE_ACCOUNT_BACKEND_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/6
+            - name: KPI_BROKER_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/2
+            - name: CACHE_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/4
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kpi

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -49,6 +49,46 @@ spec:
             initialDelaySeconds: 5
           resources:
             {{- toYaml .Values.kpi.resources | nindent 12 }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgres://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/koboform
+            - name: KC_DATABASE_URL
+              value: postgis://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.mongodb.fullname" .) .Values.mongodb.auth.existingSecret }}
+                  key: mongodb-passwords
+            - name: MONGO_DB_URL
+              value: mongodb://root:$(MONGODB_PASSWORD)@{{ (include "kobo.mongodb.fullname" .) }}:27017
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
+                  key: redis-password
+            - name: REDIS_SESSION_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/1
+            - name: SERVICE_ACCOUNT_BACKEND_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/6
+            - name: KPI_BROKER_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/2
+            - name: CACHE_URL
+              value: redis://:$(REDIS_PASSWORD)@{{ (include "kobo.redis.fullname" .) }}-master:6379/4
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kpi

--- a/templates/kpi/pre-install-job.yaml
+++ b/templates/kpi/pre-install-job.yaml
@@ -23,12 +23,22 @@ spec:
         imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
         command: ["./manage.py","migrate"]
         env:
-          - name: DATABASE_URL
-            value: {{ required "kpi.env.secret.DATABASE_URL is a required value." .Values.kpi.env.secret.DATABASE_URL }}
-          - name: KC_DATABASE_URL
-            value: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
           - name: DJANGO_SECRET_KEY
             value: {{ required "djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}
+          {{- if .Values.postgresql.enabled }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                key: postgres-password
+          - name: DATABASE_URL
+            value: postgres://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/koboform
+          - name: KC_DATABASE_URL
+            value: postgres://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+          {{- else }}
+          - name: DATABASE_URL
+            value: {{ required "kpi.env.secret.DATABASE_URL is a required value." .Values.kpi.env.secret.DATABASE_URL }}
+          {{- end }}
         {{- range $k, $v := .Values.kpi.env.normal }}
           - name: {{ $k }}
             value: {{ $v | quote }}

--- a/templates/kpi/secrets.yaml
+++ b/templates/kpi/secrets.yaml
@@ -7,16 +7,22 @@ metadata:
 type: Opaque
 data:
   DJANGO_SECRET_KEY: {{ .Values.kobotoolbox.djangoSecret | b64enc | quote }}
-  KC_DATABASE_URL: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase | b64enc | quote }}
-  MONGO_DB_URL: {{ required "mongoDatabase required" .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
+{{ if .Values.kobotoolbox.kobocatDatabase }}
+  KC_DATABASE_URL: {{ .Values.kobotoolbox.kobocatDatabase | b64enc | quote }}
+{{ end }}
+{{ if .Values.kobotoolbox.mongoDatabase }}
+  MONGO_DB_URL: {{ .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
+{{ end }}
 {{ if .Values.kobotoolbox.redis }}
   REDIS_SESSION_URL: {{ printf "%s/1" .Values.kobotoolbox.redis | b64enc | quote }}
   SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6" .Values.kobotoolbox.redis | b64enc | quote }}
   KPI_BROKER_URL: {{ printf "%s/2" .Values.kobotoolbox.redis | b64enc | quote }}
   CACHE_URL: {{ printf "%s/4" .Values.kobotoolbox.redis | b64enc | quote }}
-{{ else }}
-  REDIS_SESSION_URL: {{ required "redisSession required" .Values.kobotoolbox.redisSession | b64enc | quote }}
-  SERVICE_ACCOUNT_BACKEND_URL: {{ required "serviceAccountBackend required" .Values.kobotoolbox.serviceAccountBackend | b64enc | quote }}
+{{ else if .Values.kobotoolbox.redisSession }}
+  REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
+{{ if .Values.kobotoolbox.serviceAccountBackend }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ .Values.kobotoolbox.serviceAccountBackend | b64enc | quote }}
+{{ end }}
 {{ end }}
   ENKETO_API_KEY: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
   # -- Alias for Enketo API key. Still in used but deprecated

--- a/values.yaml
+++ b/values.yaml
@@ -17,7 +17,7 @@ kobotoolbox:
   #redis: "redis://:pass@redis-master:6379"  # Do not add / nor /1 suffix
   #redisSession: "redis://:pass@redis-master:6379/1"
   #serviceAccountBackend: "redis://:pass@redis-master:6379/1"
-  djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt tr zh-hans"
+  djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt ru tr uk zh-hans"
   enketoApiKey: "change_me_please"
 
 preInstall:

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ kobotoolbox:
   # - Service account - 6
   #redis: "redis://:pass@redis-master:6379"  # Do not add / nor /1 suffix
   #redisSession: "redis://:pass@redis-master:6379/1"
-  #serviceAccountBackend: "redis://:pass@redis-master:6379/1"
+  #serviceAccountBackend: "redis://:pass@redis-master:6379/6"
   djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt ru tr uk zh-hans"
   enketoApiKey: "change_me_please"
 
@@ -147,9 +147,8 @@ kobocat:
     normal: {}
       # KOBOCAT_DEFAULT_FILE_STORAGE: "storages.backends.s3boto3.S3Boto3Storage"
       # KOBOCAT_AWS_STORAGE_BUCKET_NAME: ""
-    secret:
-      # Overwrite these
-      # KOBOCAT_BROKER_URL: "redis://localhost:6379/1"
+    secret: {}
+      # KOBOCAT_BROKER_URL: "redis://localhost:6379/3"
       # KOBOCAT_AWS_ACCESS_KEY_ID: ""
       # KOBOCAT_AWS_SECRET_ACCESS_KEY: ""
   ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -2,8 +2,8 @@
 kobotoolbox:
   djangoSecret: "change_me_please"
   mongoName: "formhub"
-  mongoDatabase: "mongodb://root:password@mongodb:27017"
-  kobocatDatabase: "postgis://postgres:password@postgres-postgresql:5432/postgres"
+  # mongoDatabase: "mongodb://root:password@mongodb:27017"
+  # kobocatDatabase: "postgis://postgres:password@postgres-postgresql:5432/postgres"
   # Set to use for all redis needs (cache, broker, etc) redis connection string without db number.
   # Unset to specify each redis usage seperately
   # Redis default DB numbers
@@ -14,7 +14,7 @@ kobotoolbox:
   # - KPI Cache - 4
   # - Kobocat Cache - 5
   # - Service account - 6
-  redis: "redis://:pass@redis-master:6379"  # Do not add / nor /1 suffix
+  #redis: "redis://:pass@redis-master:6379"  # Do not add / nor /1 suffix
   #redisSession: "redis://:pass@redis-master:6379/1"
   #serviceAccountBackend: "redis://:pass@redis-master:6379/1"
   djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt tr zh-hans"
@@ -64,8 +64,8 @@ kpi:
       # -- KoBoCAT Bucket name 
       # KOBOCAT_AWS_STORAGE_BUCKET_NAME: ""
     secret:
-      # Overwrite these
-      DATABASE_URL: "postgres://postgres:password@postgres-postgresql:5432/postgres"
+      {}
+      # DATABASE_URL: "postgres://postgres:password@postgres-postgresql:5432/postgres"
       # KPI_BROKER_URL: "redis://localhost:6379/1"
       # CACHE_URL: "redis://localhost:6379/1"
       # AWS_ACCESS_KEY_ID: ""
@@ -297,7 +297,6 @@ nginx:
 mongodb:
   enabled: false
   architecture: "replicaset"
-  replicaCount: 3
   pdb:
     create: true
   initdbScripts:

--- a/values.yaml
+++ b/values.yaml
@@ -358,6 +358,10 @@ postgresql:
   primary:
     persistence:
       size: 10Gi
+    initdb:
+      scripts:
+        create-koboform.sql: |
+          CREATE DATABASE koboform;
     resources:
       limits:
         cpu: 1000m


### PR DESCRIPTION
When using the helm managed postgres, mongo, and redis - it is no longer necessary to set connection string URLS which duplicate the password.

The method used references the Kubernetes secret object and builds the relevant URL. There is some necessary duplication as we have many deployments. Previously a secret or configmap would have reduced the duplication but these new variables must reference existing secrets and therefor cannot be a secret themselves.

Users who don't make use of these helm managed services should make no changes and continue to set the full URL string.

See the internal "billing" deployment for an example of using this change. Note the lack of database connection strings.

Removes need to manually create a second postgres database when using the provided postgres helm chart.