### PR TITLE
Add redis parameters option

### DIFF
--- a/templates/enketo/secrets.yaml
+++ b/templates/enketo/secrets.yaml
@@ -8,8 +8,8 @@ type: Opaque
 data:
   ENKETO_LINKED_FORM_AND_DATA_SERVER_API_KEY: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
 {{ if .Values.kobotoolbox.redis }}
-  ENKETO_REDIS_MAIN_URL: {{ .Values.kobotoolbox.redis | b64enc | quote }}
-  ENKETO_REDIS_CACHE_URL: {{ .Values.kobotoolbox.redis | b64enc | quote }}
+  ENKETO_REDIS_MAIN_URL: {{ printf "%s%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  ENKETO_REDIS_CACHE_URL: {{ printf "%s%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ end }}
 {{- range $k, $v := .Values.enketo.env.secret }}
   {{ $k }}: {{ $v | b64enc | quote }}

--- a/templates/kobocat/secrets.yaml
+++ b/templates/kobocat/secrets.yaml
@@ -14,10 +14,10 @@ data:
   MONGO_DB_URL: {{ .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
 {{ end }}
 {{ if .Values.kobotoolbox.redis }}
-  REDIS_SESSION_URL: {{ printf "%s/1" .Values.kobotoolbox.redis | b64enc | quote }}
-  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6" .Values.kobotoolbox.redis | b64enc | quote }}
-  KOBOCAT_BROKER_URL: {{ printf "%s/3" .Values.kobotoolbox.redis | b64enc | quote }}
-  CACHE_URL: {{ printf "%s/5" .Values.kobotoolbox.redis | b64enc | quote }}
+  REDIS_SESSION_URL: {{ printf "%s/1%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  KOBOCAT_BROKER_URL: {{ printf "%s/3%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  CACHE_URL: {{ printf "%s/5%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ else if .Values.kobotoolbox.redisSession }}
   REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
 {{ if .Values.kobotoolbox.serviceAccountBackend }}

--- a/templates/kpi/secrets.yaml
+++ b/templates/kpi/secrets.yaml
@@ -14,10 +14,10 @@ data:
   MONGO_DB_URL: {{ .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
 {{ end }}
 {{ if .Values.kobotoolbox.redis }}
-  REDIS_SESSION_URL: {{ printf "%s/1" .Values.kobotoolbox.redis | b64enc | quote }}
-  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6" .Values.kobotoolbox.redis | b64enc | quote }}
-  KPI_BROKER_URL: {{ printf "%s/2" .Values.kobotoolbox.redis | b64enc | quote }}
-  CACHE_URL: {{ printf "%s/4" .Values.kobotoolbox.redis | b64enc | quote }}
+  REDIS_SESSION_URL: {{ printf "%s/1%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  KPI_BROKER_URL: {{ printf "%s/2%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  CACHE_URL: {{ printf "%s/4%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ else if .Values.kobotoolbox.redisSession }}
   REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
 {{ if .Values.kobotoolbox.serviceAccountBackend }}

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,7 @@ kobotoolbox:
   # - Kobocat Cache - 5
   # - Service account - 6
   #redis: "redis://:pass@redis-master:6379"  # Do not add / nor /1 suffix
+  redisParameters: "" # ?ssl_cert_reqs=CERT_REQUIRED
   #redisSession: "redis://:pass@redis-master:6379/1"
   #serviceAccountBackend: "redis://:pass@redis-master:6379/6"
   djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt ru tr uk zh-hans"


### PR DESCRIPTION
When using a service like AWS's ElasticCache with SSL enabled, there needs to be a few changes made to the redis URL. First, the scheme needs to be changed to `rediss`. This could be done already. The other change that is needed is to add a parameter to the end of the url like `?ssl_cert_reqs=CERT_REQUIRED`. The problem with the existing configuration is that the database, e.g `\6` was added to the end of the url string, and the parameters need to be located after the database URL. To accomplish this, I added a new `redisParameters` section to the kobotoolbox section which defaults to an empty string, and then changed the redis variables to include this in the URL format. I've tested this locally with our Kobo deployment and it's working correctly with Elasticache.