### PR TITLE
Enable nginx level gzip

### DIFF
--- a/files/kobocat/nginx.conf
+++ b/files/kobocat/nginx.conf
@@ -7,6 +7,25 @@ server {
 
     client_max_body_size 100M;
 
+    gzip on;
+    gzip_disable "msie6";
+    gzip_comp_level 6;
+    gzip_min_length 1100;
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/xml+rss
+        image/svg+xml;
+
     location /static {
         autoindex on;
         alias /static;

--- a/files/kpi/nginx.conf
+++ b/files/kpi/nginx.conf
@@ -6,6 +6,26 @@ upstream backend {
 server {
 
     client_max_body_size 100M;
+
+    gzip on;
+    gzip_disable "msie6";
+    gzip_comp_level 6;
+    gzip_min_length 1100;
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/xml+rss
+        image/svg+xml;
+
     
     location ~ ^/protected-s3/(.*)$ {
         # Allow internal requests only, i.e. return a 404 to any client who


### PR DESCRIPTION
## Description

Enable gzip in nginx containers for both kpi and kobocat

## Details

Uses same configuration as [kobo-docker](https://github.com/kobotoolbox/kobo-docker/blob/master/nginx/kobo-docker-scripts/nginx.conf#L55)