### PR TITLE
Extra volumes

### DIFF
--- a/templates/enketo/deployment.yaml
+++ b/templates/enketo/deployment.yaml
@@ -69,6 +69,10 @@ spec:
                 name: {{ include "kobo.fullname" . }}-enketo
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-enketo
+          {{- with .Values.enketo.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.enketo.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -88,3 +92,7 @@ spec:
         labelSelector:
           matchLabels:
             app.kubernetes.io/component: enketo
+      {{- with .Values.enketo.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/templates/kobocat/deployment-beat.yaml
+++ b/templates/kobocat/deployment-beat.yaml
@@ -80,7 +80,10 @@ spec:
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kobocat
           command: ["celery", "-A", "onadata", "beat", "-l", "info", "--pidfile=/tmp/celery_beat.pid", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]
-
+          {{- with .Values.kobocat.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.kobocat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -92,4 +95,8 @@ spec:
       {{- with .Values.kobocat.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kobocat.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/templates/kobocat/deployment-worker.yaml
+++ b/templates/kobocat/deployment-worker.yaml
@@ -77,7 +77,10 @@ spec:
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kobocat
           command: ["celery", "-A", "onadata", "worker", "-l", "info", "-Ofair", "--hostname=kobocat_main_worker@%h"]
-
+          {{- with .Values.kobocat.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.kobocat.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -89,4 +92,8 @@ spec:
       {{- with .Values.kobocat.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kobocat.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/templates/kobocat/deployment.yaml
+++ b/templates/kobocat/deployment.yaml
@@ -96,6 +96,9 @@ spec:
           volumeMounts:
           - name: scripts
             mountPath: /srv/init/
+          {{- with .Values.kobocat.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
         - name: nginx
           image: {{ .Values.nginx.image }}
           imagePullPolicy: Always
@@ -123,12 +126,14 @@ spec:
             mountPath: /static    
           - name: scripts
             mountPath: /srv/init/
+          {{- with .Values.kobocat.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kobocat
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kobocat
-
       {{- with .Values.kobocat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -163,3 +168,6 @@ spec:
       - name: nginx-conf
         configMap:
           name: {{ include "kobo.fullname" . }}-nginx-kobocat-conf
+      {{- with .Values.kobocat.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/templates/kobocat/pre-install-job.yaml
+++ b/templates/kobocat/pre-install-job.yaml
@@ -41,4 +41,12 @@ spec:
           - name: {{ $k }}
             value: {{ $v | quote }}
         {{- end }}
+        {{- with .Values.kobocat.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.kobocat.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/templates/kpi/deployment-beat.yaml
+++ b/templates/kpi/deployment-beat.yaml
@@ -82,7 +82,10 @@ spec:
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
           command: ["celery", "-A", "kobo", "beat", "-l", "info", "--pidfile=/tmp/celery_beat.pid", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]
-
+          {{- with .Values.kobocat.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.kpi.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -94,4 +97,8 @@ spec:
       {{- with .Values.kpi.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kobocat.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -79,7 +79,10 @@ spec:
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
           command: ["celery", "-A", "kobo", "worker", "--queues=kpi_low_priority_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--concurrency", "2"]
-
+          {{- with .Values.kobocat.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.kpi.workerLowPriority.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -91,4 +94,8 @@ spec:
       {{- with .Values.kpi.workerLowPriority.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kobocat.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -79,7 +79,10 @@ spec:
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
           command: ["celery", "-A", "kobo", "worker", "--queues", "kpi_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--concurrency", "2"]
-
+          {{- with .Values.kobocat.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.kpi.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -91,4 +94,8 @@ spec:
       {{- with .Values.kpi.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kobocat.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -36,17 +36,17 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /accounts/login/
-              port: http
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /accounts/login/
-              port: http
-            initialDelaySeconds: 5
+{{/*          livenessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /accounts/login/*/}}
+{{/*              port: http*/}}
+{{/*            initialDelaySeconds: 5*/}}
+{{/*            timeoutSeconds: 5*/}}
+{{/*          readinessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /accounts/login/*/}}
+{{/*              port: http*/}}
+{{/*            initialDelaySeconds: 5*/}}
           resources:
             {{- toYaml .Values.kpi.resources | nindent 12 }}
           env:
@@ -100,6 +100,9 @@ spec:
             mountPath: /srv/static
           - name: scripts
             mountPath: /srv/init/
+          {{- with .Values.kpi.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
         - name: nginx
           image: {{ .Values.nginx.image }}
           imagePullPolicy: Always
@@ -117,7 +120,6 @@ spec:
             mountPath: /etc/nginx/conf.d/
           ports:
             - containerPort: 80
-
       {{- with .Values.kpi.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -150,3 +152,6 @@ spec:
       - name: nginx-conf
         configMap:
           name: {{ include "kobo.fullname" . }}-nginx-kpi-conf
+      {{- with .Values.kpi.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -36,17 +36,17 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-{{/*          livenessProbe:*/}}
-{{/*            httpGet:*/}}
-{{/*              path: /accounts/login/*/}}
-{{/*              port: http*/}}
-{{/*            initialDelaySeconds: 5*/}}
-{{/*            timeoutSeconds: 5*/}}
-{{/*          readinessProbe:*/}}
-{{/*            httpGet:*/}}
-{{/*              path: /accounts/login/*/}}
-{{/*              port: http*/}}
-{{/*            initialDelaySeconds: 5*/}}
+          livenessProbe:
+            httpGet:
+              path: /accounts/login/
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /accounts/login/
+              port: http
+            initialDelaySeconds: 5
           resources:
             {{- toYaml .Values.kpi.resources | nindent 12 }}
           env:

--- a/templates/kpi/pre-install-job.yaml
+++ b/templates/kpi/pre-install-job.yaml
@@ -45,4 +45,12 @@ spec:
           - name: {{ $k }}
             value: {{ $v | quote }}
         {{- end }}
+        {{- with .Values.kpi.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.kpi.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -71,6 +71,8 @@ kpi:
       # CACHE_URL: "redis://localhost:6379/4"
       # AWS_ACCESS_KEY_ID: ""
       # AWS_SECRET_ACCESS_KEY: ""
+  extraVolumeMounts: []
+  extraVolumes: []
   worker:
     replicaCount: 1
     resources:
@@ -166,6 +168,8 @@ kobocat:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+  extraVolumeMounts: [ ]
+  extraVolumes: [ ]
   worker:
     replicaCount: 1
     resources:
@@ -273,6 +277,8 @@ enketo:
       # Set if kobotoolbox.redis is unset
       # ENKETO_REDIS_MAIN_URL: "redis://localhost:6379"
       # ENKETO_REDIS_CACHE_URL: "redis://localhost:6379"
+  extraVolumeMounts: [ ]
+  extraVolumes: [ ]
   ingress:
     enabled: false
     className: ""


### PR DESCRIPTION
This PR enables the option to provide extra volumes and extra volume mounts to each of the Kobo containers. This could be useful for a number of occasions such as injecting additional CA certificates or config files. This was modeled after similar features on Bitnami charts and other open source helm charts.