### PR TITLE
Implement Image Pull Secrets

### DIFF
--- a/templates/enketo/secrets.yaml
+++ b/templates/enketo/secrets.yaml
@@ -8,8 +8,8 @@ type: Opaque
 data:
   ENKETO_LINKED_FORM_AND_DATA_SERVER_API_KEY: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
 {{ if .Values.kobotoolbox.redis }}
-  ENKETO_REDIS_MAIN_URL: {{ .Values.kobotoolbox.redis | b64enc | quote }}
-  ENKETO_REDIS_CACHE_URL: {{ .Values.kobotoolbox.redis | b64enc | quote }}
+  ENKETO_REDIS_MAIN_URL: {{ printf "%s%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  ENKETO_REDIS_CACHE_URL: {{ printf "%s%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ end }}
 {{- range $k, $v := .Values.enketo.env.secret }}
   {{ $k }}: {{ $v | b64enc | quote }}

--- a/templates/kobocat/secrets.yaml
+++ b/templates/kobocat/secrets.yaml
@@ -14,10 +14,10 @@ data:
   MONGO_DB_URL: {{ .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
 {{ end }}
 {{ if .Values.kobotoolbox.redis }}
-  REDIS_SESSION_URL: {{ printf "%s/1" .Values.kobotoolbox.redis | b64enc | quote }}
-  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6" .Values.kobotoolbox.redis | b64enc | quote }}
-  KOBOCAT_BROKER_URL: {{ printf "%s/3" .Values.kobotoolbox.redis | b64enc | quote }}
-  CACHE_URL: {{ printf "%s/5" .Values.kobotoolbox.redis | b64enc | quote }}
+  REDIS_SESSION_URL: {{ printf "%s/1%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  KOBOCAT_BROKER_URL: {{ printf "%s/3%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  CACHE_URL: {{ printf "%s/5%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ else if .Values.kobotoolbox.redisSession }}
   REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
 {{ if .Values.kobotoolbox.serviceAccountBackend }}

--- a/templates/kpi/secrets.yaml
+++ b/templates/kpi/secrets.yaml
@@ -14,10 +14,10 @@ data:
   MONGO_DB_URL: {{ .Values.kobotoolbox.mongoDatabase | b64enc | quote }}
 {{ end }}
 {{ if .Values.kobotoolbox.redis }}
-  REDIS_SESSION_URL: {{ printf "%s/1" .Values.kobotoolbox.redis | b64enc | quote }}
-  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6" .Values.kobotoolbox.redis | b64enc | quote }}
-  KPI_BROKER_URL: {{ printf "%s/2" .Values.kobotoolbox.redis | b64enc | quote }}
-  CACHE_URL: {{ printf "%s/4" .Values.kobotoolbox.redis | b64enc | quote }}
+  REDIS_SESSION_URL: {{ printf "%s/1%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  KPI_BROKER_URL: {{ printf "%s/2%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  CACHE_URL: {{ printf "%s/4%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ else if .Values.kobotoolbox.redisSession }}
   REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
 {{ if .Values.kobotoolbox.serviceAccountBackend }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -9,4 +9,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if .Values.imagePullSecrets }}
+{{- range .Values.imagePullSecrets }}
+imagePullSecrets:
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,7 @@ kobotoolbox:
   # - Kobocat Cache - 5
   # - Service account - 6
   #redis: "redis://:pass@redis-master:6379"  # Do not add / nor /1 suffix
+  redisParameters: "" # ?ssl_cert_reqs=CERT_REQUIRED
   #redisSession: "redis://:pass@redis-master:6379/1"
   #serviceAccountBackend: "redis://:pass@redis-master:6379/6"
   djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt ru tr uk zh-hans"


### PR DESCRIPTION
The .Values file for had a spot for imagePullSecrets, but this was never implemented in the service account. This adds the functionality to add them to the service account by providing a list of secret names to add to the imagePullSecrets section of the service account spec, e.g.:
```yaml
imagePullSecrets:
  -  my-docker-secret
```