### PR TITLE
show correct kpi/kobocat instructions in notes

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -13,7 +13,7 @@
   {{- else if contains "LoadBalancer" ( get ( get ( index $.Values $app ) "service" ) "type" ) }}
       NOTE: It may take a few minutes for the LoadBalancer IP to be available.
             You can watch the status of by running 'kubectl get --namespace {{ $.Release.Namespace }} svc -w {{ include "kobo.fullname" $ }}'
-    export SERVICE_IP=$(kubectl get svc --namespace {{ $.Release.Namespace }} {{ include "kobo.fullname" $ }} --template "{{"{{ range (index $.status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    export SERVICE_IP=$(kubectl get svc --namespace {{ $.Release.Namespace }} {{ include "kobo.fullname" $ }} --template "{{"{{ range (index $.status.loadBalancer.ingress 0) }}{{$}}{{ end }}"}}")
     echo http://$SERVICE_IP:{{ get ( get ( index $.Values $app ) "service" ) "port" }}
   {{- else if contains "ClusterIP" ( get ( get ( index $.Values $app ) "service" ) "type" ) }}
     export POD_NAME=$(kubectl get pods --namespace {{ $.Release.Namespace }} -l "app.kubernetes.io/name={{ include "kobo.name" $ }},app.kubernetes.io/instance={{ $.Release.Name }},app.kubernetes.io/component={{ $app }}" -o jsonpath="{.items[0].metadata.name}")

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -3,7 +3,7 @@
   {{- if get ( get ( index $.Values $app ) "ingress" ) "enabled" }}
     {{- range $host := get ( get ( index $.Values $app ) "ingress" ) "hosts" }}
       {{- range .paths }}
-      http{{ if ( get ( get ( index $.Values $app ) "ingress" ) "hosts" ) }}s{{ end }}://{{ $host.host }}{{ .path }}
+      http{{ if ( get ( get ( index $.Values $app ) "ingress" ) "hosts" ) }}s{{ end }}://{{ $host.host }}{{ $.path }}
       {{- end }}
     {{- end }}
     {{- else if contains "NodePort" ( get ( get ( index $.Values $app ) "service" ) "type" ) }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,68 +1,25 @@
-1. Get the kpi application URL by running these commands:
-{{- if .Values.kpi.ingress.enabled }}
-{{- range $host := .Values.kpi.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.kpi.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+{{- range $index, $app := tuple "enketo" "kobocat" "kpi" }}
+  {{- add $index 1 }}. Get the {{ $app }} application URL by running these commands:
+  {{- if get ( get ( index $.Values $app ) "ingress" ) "enabled" }}
+    {{- range $host := get ( get ( index $.Values $app ) "ingress" ) "hosts" }}
+      {{- range .paths }}
+      http{{ if ( get ( get ( index $.Values $app ) "ingress" ) "hosts" ) }}s{{ end }}://{{ $host.host }}{{ .path }}
+      {{- end }}
+    {{- end }}
+    {{- else if contains "NodePort" ( get ( get ( index $.Values $app ) "service" ) "type" ) }}
+    export NODE_PORT=$(kubectl get --namespace {{ $.Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kobo.fullname" $ }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ $.Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo http://$NODE_IP:$NODE_PORT
+  {{- else if contains "LoadBalancer" ( get ( get ( index $.Values $app ) "service" ) "type" ) }}
+      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+            You can watch the status of by running 'kubectl get --namespace {{ $.Release.Namespace }} svc -w {{ include "kobo.fullname" $ }}'
+    export SERVICE_IP=$(kubectl get svc --namespace {{ $.Release.Namespace }} {{ include "kobo.fullname" $ }} --template "{{"{{ range (index $.status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    echo http://$SERVICE_IP:{{ get ( get ( index $.Values $app ) "service" ) "port" }}
+  {{- else if contains "ClusterIP" ( get ( get ( index $.Values $app ) "service" ) "type" ) }}
+    export POD_NAME=$(kubectl get pods --namespace {{ $.Release.Namespace }} -l "app.kubernetes.io/name={{ include "kobo.name" $ }},app.kubernetes.io/instance={{ $.Release.Name }},app.kubernetes.io/component={{ $app }}" -o jsonpath="{.items[0].metadata.name}")
+    export CONTAINER_PORT=$(kubectl get pod --namespace {{ $.Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+    echo "Visit http://127.0.0.1:8080 to use your application"
+    kubectl --namespace {{ $.Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
   {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.kpi.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kobo.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.kpi.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kobo.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kobo.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.kpi.service.port }}
-{{- else if contains "ClusterIP" .Values.kpi.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kobo.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
 
-1. Get the kobocat application URL by running these commands:
-{{- if .Values.kobocat.ingress.enabled }}
-{{- range $host := .Values.kobocat.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.kobocat.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.kobocat.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kobo.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.kobocat.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kobo.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kobo.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.kobocat.service.port }}
-{{- else if contains "ClusterIP" .Values.kobocat.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kobo.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
-
-1. Get the enketo application URL by running these commands:
-{{- if .Values.enketo.ingress.enabled }}
-{{- range $host := .Values.enketo.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.enketo.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.enketo.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kobo.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.enketo.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kobo.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kobo.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.enketo.service.port }}
-{{- else if contains "ClusterIP" .Values.enketo.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kobo.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+{{ end }}


### PR DESCRIPTION
This PR refactors the notes that are output after installing. Currently, it prints 3 sets of instructions for kobocat, kpi, and enketo, but each just exposes the port for enketo. Condensed the template a bit for DRY, although the added nested `get` functions impact readability - if there's a less wordy way to accomplish the same thing, let me know.