### PR TITLE
Enable celery autoscaling, with default of 2,3

### DIFF
--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -82,7 +82,7 @@ spec:
                 name: {{ include "kobo.fullname" . }}-kpi
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
-          command: ["celery", "-A", "kobo", "worker", "--queues=kpi_low_priority_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--concurrency", "2"]
+          command: ["celery", "-A", "kobo", "worker", "--queues=kpi_low_priority_queue", "-l", "info", "--hostname=kpi_main_worker@%h"]
           {{- with .Values.kobocat.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 10 }}

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -82,7 +82,7 @@ spec:
                 name: {{ include "kobo.fullname" . }}-kpi
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
-          command: ["celery", "-A", "kobo", "worker", "--queues", "kpi_queue", "-l", "info", "--hostname=kpi_main_worker@%h", "--concurrency", "2"]
+          command: ["celery", "-A", "kobo", "worker", "--queues", "kpi_queue", "-l", "info", "--hostname=kpi_main_worker@%h"]
           {{- with .Values.kobocat.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -197,6 +197,9 @@ kobocat:
       KOBOCAT_PUBLIC_SUBDOMAIN: "kc"
       KOBOFORM_PUBLIC_SUBDOMAIN: "kobo"
       PUBLIC_REQUEST_SCHEME: "https"
+      # Celery configuration
+      CELERY_WORKER_AUTOSCALE: "2,3"
+      CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
       # KOBOCAT_DEFAULT_FILE_STORAGE: "storages.backends.s3boto3.S3Boto3Storage"
       # KOBOCAT_AWS_STORAGE_BUCKET_NAME: ""
     secret: {}

--- a/values.yaml
+++ b/values.yaml
@@ -64,6 +64,9 @@ kpi:
       KOBOCAT_PUBLIC_SUBDOMAIN: "kc"
       KOBOFORM_PUBLIC_SUBDOMAIN: "kobo"
       PUBLIC_REQUEST_SCHEME: "https"
+      # Celery configuration
+      CELERY_WORKER_AUTOSCALE: "2,3"
+      CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
       # -- Django email backend
       EMAIL_BACKEND: "django.core.mail.backends.console.EmailBackend"
       # -- Django file storage, recommend using a django-storages approach for scalability


### PR DESCRIPTION
Instead of setting it as the command, we set it via the overridable env var.

Combined with memory based hpa, we can scale when getting too many low-cpu tasks. However this is not enabled by default and is tricky to get right for the specific instance.

I tested this by deploying to a staging server and observing the logs. 

> concurrency: {min=2, max=3}