### PR TITLE
Add redis to pre-install

### DIFF
--- a/templates/kpi/pre-install-job.yaml
+++ b/templates/kpi/pre-install-job.yaml
@@ -45,6 +45,10 @@ spec:
           - name: KC_DATABASE_URL
             value: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
           {{- end }}
+          {{ if .Values.kobotoolbox.redis }}
+          - name: CACHE_URL
+            value: {{ printf "%s/5%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | quote }}
+          {{- end }}
         {{- range $k, $v := .Values.kpi.env.normal }}
           - name: {{ $k }}
             value: {{ $v | quote }}


### PR DESCRIPTION
We sometimes need access to redis to run migrations. Use the same strategy as the database url, where it goes directly there instead of a mapping. We need this to prevent it from referring old settings.

This change does not merit it's own release.