### PR TITLE
allow connection to an external database, with a custom username and database name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: Helm Chart Testing and Artifact Build
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - main
+      - develop
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: 'v3.13.0' # You can specify the Helm version you want to use
+
+    - name: Install Helm Chart Dependencies
+      run: |
+        helm dependency update
+
+    - name: Lint Helm Chart
+      run: |
+        helm lint .
+
+    - name: Package Chart
+      run: |
+        helm package -d chart .
+        mv chart/kobo*.tgz chart/kobo.tgz 
+   

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,7 +103,7 @@ PostgreSQL connection URL
 Requires POSTGRES_PASSWORD to be set environment variable
 */}}
 {{- define "kobo.postgresql.url" -}}
-{{- printf "postgres://postgres:$(POSTGRES_PASSWORD)@%s:5432/koboform" (include "kobo.postgresql.fullname" .) -}}
+{{- printf "postgres://%s:$(POSTGRES_PASSWORD)@%s:5432/%s" .Values.postgresql.auth.username (include "kobo.postgresql.fullname" .) .Values.kpi.env.normal.KPI_DATABASE_NAME -}}
 {{- end -}}
 
 {{/*
@@ -111,8 +111,9 @@ PostgreSQL connection URL for KoboCat
 Requires POSTGRES_PASSWORD to be set environment variable
 */}}
 {{- define "kobo.postgresql.kc_url" -}}
-{{- printf "postgis://postgres:$(POSTGRES_PASSWORD)@%s:5432/postgres" (include "kobo.postgresql.fullname" .) -}}
+{{- printf "postgis://%s:$(POSTGRES_PASSWORD)@%s:5432/%s" .Values.postgresql.auth.username (include "kobo.postgresql.fullname" .) .Values.kobocat.env.normal.KOBOCAT_DATABASE_NAME -}}
 {{- end -}}
+
 
 {{- define "kobo.mongodb.fullname" -}}
 {{- if .Values.mongodb.fullnameOverride -}}

--- a/values.yaml
+++ b/values.yaml
@@ -84,6 +84,7 @@ kpi:
       # KOBOCAT_DEFAULT_FILE_STORAGE: "storages.backends.s3boto3.S3Boto3Storage"
       # -- KoBoCAT Bucket name
       # KOBOCAT_AWS_STORAGE_BUCKET_NAME: ""
+      KPI_DATABASE_NAME: koboform
     secret:
       {}
       # DATABASE_URL: "postgres://postgres:password@postgres-postgresql:5432/postgres"
@@ -209,6 +210,7 @@ kobocat:
       CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
       # KOBOCAT_DEFAULT_FILE_STORAGE: "storages.backends.s3boto3.S3Boto3Storage"
       # KOBOCAT_AWS_STORAGE_BUCKET_NAME: ""
+      KOBOCAT_DATABASE_NAME: kobocat
     secret: {}
       # KOBOCAT_BROKER_URL: "redis://localhost:6379/3"
       # KOBOCAT_AWS_ACCESS_KEY_ID: ""
@@ -452,6 +454,10 @@ redis:
 postgresql:
   enabled: false
   auth:
+    # Name for a custom user to create
+    username: "custom_user"
+    # Password for the custom user to create. Ignored if auth.existingSecret is provided
+    password: "change_me_please"
     postgresPassword: "change_me_please"
   primary:
     persistence:


### PR DESCRIPTION
We sometimes need to connect to a managed instance of Postgres that does not allow the use of the Postgres user.
Thus we need to allow the use of a custom username.

We might also need to run more than one instance of Kobocat and KPI on the same database server. So there is need to allow custom/variable database names