### PR TITLE
Remove django language codes value, prefer default

### DIFF
--- a/templates/kobocat/configmap.yaml
+++ b/templates/kobocat/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     "helm.sh/hook-weight": "-1"
 data:
   KOBOCAT_MONGO_NAME: {{ required "mongoName is required" .Values.kobotoolbox.mongoName }}
-  DJANGO_LANGUAGE_CODES: {{ quote .Values.kobotoolbox.djangoLanguageCodes }}
 {{- if .Values.kpi.ingress.enabled }}
   KOBOFORM_URL: {{ include "kobo.kpiUrl" . | quote }}
 {{- end }}

--- a/templates/kpi/configmap.yaml
+++ b/templates/kpi/configmap.yaml
@@ -10,7 +10,6 @@ metadata:
 data:
   ENKETO_VERSION: "Express"
   KPI_MONGO_NAME: {{ required "mongoName is required" .Values.kobotoolbox.mongoName }}
-  DJANGO_LANGUAGE_CODES: {{ quote .Values.kobotoolbox.djangoLanguageCodes }}
 {{- if .Values.kpi.ingress.enabled }}
   KOBOFORM_URL: {{ include "kobo.kpiUrl" . | quote }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,6 @@ kobotoolbox:
   redisParameters: "" # ?ssl_cert_reqs=CERT_REQUIRED
   #redisSession: "redis://:pass@redis-master:6379/1"
   #serviceAccountBackend: "redis://:pass@redis-master:6379/6"
-  djangoLanguageCodes: "ar cs de-DE en es fr hi ku pl pt ru tr uk zh-hans"
   enketoApiKey: "change_me_please"
 
 preInstall:


### PR DESCRIPTION
Resolves https://github.com/kobotoolbox/kobo-helm-chart/issues/39

# Notes

I decided to remove djangoLanguageCodes entirely. We can still set it via a regular environment variable. It's rare we would set this.