### PR TITLE
Use minimal service health URL for health checks

### DIFF
--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -45,13 +45,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /accounts/login/
+              path: /service_health/minimal/
               port: http
             initialDelaySeconds: 5
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /accounts/login/
+              path: /service_health/minimal/
               port: http
             initialDelaySeconds: 5
           resources:


### PR DESCRIPTION
This check doesn't require redis/postgres to be operational. It's faster and won't cause additional service load + degradation when one of those services is down. It's not desired to restart the web pod when such a service is down.