### PR TITLE
Disable NGINX directory indexing of static files

### DIFF
--- a/files/kobocat/nginx.conf
+++ b/files/kobocat/nginx.conf
@@ -27,7 +27,6 @@ server {
         image/svg+xml;
 
     location /static {
-        autoindex on;
         alias /static;
     }
 

--- a/files/kpi/nginx.conf
+++ b/files/kpi/nginx.conf
@@ -26,7 +26,7 @@ server {
         application/xml+rss
         image/svg+xml;
 
-    
+
     location ~ ^/protected-s3/(.*)$ {
         # Allow internal requests only, i.e. return a 404 to any client who
         # tries to access this location directly
@@ -59,7 +59,6 @@ server {
     }
 
     location /static {
-        autoindex on;
         alias /static;
     }
 


### PR DESCRIPTION
These are in public git repositories, but avoid `autoindex on` as a good practice and precaution