### PR TITLE
Add `ENKETO_REDIS_MAIN_URL` env var to KPI and Kobocat pods

### DIFF
--- a/templates/kobocat/deployment-beat.yaml
+++ b/templates/kobocat/deployment-beat.yaml
@@ -65,6 +65,8 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
                   key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: {{ (include "kobo.redis.url" .) }}/0
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL

--- a/templates/kobocat/deployment-worker.yaml
+++ b/templates/kobocat/deployment-worker.yaml
@@ -66,6 +66,8 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
                   key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: {{ (include "kobo.redis.url" .) }}/0
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL

--- a/templates/kobocat/deployment.yaml
+++ b/templates/kobocat/deployment.yaml
@@ -82,6 +82,8 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
                   key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: {{ (include "kobo.redis.url" .) }}/0
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL

--- a/templates/kobocat/secrets.yaml
+++ b/templates/kobocat/secrets.yaml
@@ -18,6 +18,7 @@ data:
   SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
   KOBOCAT_BROKER_URL: {{ printf "%s/3%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
   CACHE_URL: {{ printf "%s/5%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  ENKETO_REDIS_MAIN_URL: {{ printf "%s/0%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ else if .Values.kobotoolbox.redisSession }}
   REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
 {{ if .Values.kobotoolbox.serviceAccountBackend }}

--- a/templates/kpi/deployment-beat.yaml
+++ b/templates/kpi/deployment-beat.yaml
@@ -62,6 +62,8 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
                   key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: {{ (include "kobo.redis.url" .) }}/0
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -68,6 +68,8 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
                   key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: {{ (include "kobo.redis.url" .) }}/0
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -68,6 +68,8 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
                   key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: {{ (include "kobo.redis.url" .) }}/0
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -87,6 +87,8 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "kobo.redis.fullname" .) .Values.redis.auth.existingSecret }}
                   key: redis-password
+            - name: ENKETO_REDIS_MAIN_URL
+              value: {{ (include "kobo.redis.url" .) }}/0
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL

--- a/templates/kpi/secrets.yaml
+++ b/templates/kpi/secrets.yaml
@@ -18,6 +18,7 @@ data:
   SERVICE_ACCOUNT_BACKEND_URL: {{ printf "%s/6%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
   KPI_BROKER_URL: {{ printf "%s/2%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
   CACHE_URL: {{ printf "%s/4%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
+  ENKETO_REDIS_MAIN_URL: {{ printf "%s/0%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | b64enc | quote }}
 {{ else if .Values.kobotoolbox.redisSession }}
   REDIS_SESSION_URL: {{ .Values.kobotoolbox.redisSession | b64enc | quote }}
 {{ if .Values.kobotoolbox.serviceAccountBackend }}


### PR DESCRIPTION
## Description

 `ENKETO_REDIS_MAIN_URL` is needed in KPI and Kobocat Django apps starting from release/2.024.04