### PR TITLE
Make use of kobocat minimal service health check

### DIFF
--- a/templates/kobocat/deployment.yaml
+++ b/templates/kobocat/deployment.yaml
@@ -42,13 +42,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /api/v1/
+              path: /service_health/minimal/
               port: http
             initialDelaySeconds: 5
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /api/v1/
+              path: /service_health/minimal/
               port: http
             initialDelaySeconds: 5
           resources:


### PR DESCRIPTION
Depends on https://github.com/kobotoolbox/kobocat/pull/920

Use the minimal health check so that k8s only checks if the django service is ready. It should not check external databases.