### PR TITLE
Add envFrom with secret and configmap for pre-install jobs

### DIFF
--- a/templates/kobocat/pre-install-job.yaml
+++ b/templates/kobocat/pre-install-job.yaml
@@ -49,6 +49,11 @@ spec:
           - name: {{ $k }}
             value: {{ $v | quote }}
         {{- end }}
+        envFrom:
+          - secretRef:
+              name: {{ include "kobo.fullname" . }}-kobocat
+          - configMapRef:
+              name: {{ include "kobo.fullname" . }}-kobocat
         {{- with .Values.kobocat.extraVolumeMounts }}
         volumeMounts:
           {{- toYaml . | nindent 10 }}

--- a/templates/kpi/pre-install-job.yaml
+++ b/templates/kpi/pre-install-job.yaml
@@ -53,6 +53,11 @@ spec:
           - name: {{ $k }}
             value: {{ $v | quote }}
         {{- end }}
+        envFrom:
+          - secretRef:
+              name: {{ include "kobo.fullname" . }}-kpi
+          - configMapRef:
+              name: {{ include "kobo.fullname" . }}-kpi
         {{- with .Values.kpi.extraVolumeMounts }}
         volumeMounts:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
On a deployment, I set `KPI_DEFAULT_FILE_STORAGE` to a value ending with `AzureStorage`. After setting this, pre-install jobs fail in such way:

```
django.core.exceptions.ImproperlyConfigured: Set the AZURE_ACCOUNT_KEY environment variable
```

Looks like the jobs don't have the env available from the configmap and secret, where the AZURE- envs are. This PR should fix that.