### PR TITLE
Create post install hook

### DIFF
--- a/templates/kpi/post-install-job.yaml
+++ b/templates/kpi/post-install-job.yaml
@@ -1,19 +1,16 @@
-{{- if .Values.preInstall.enabled -}}
+{{- if .Values.postInstall.command -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "kobo.fullname" . }}-kpi
+  name: {{ include "kobo.fullname" . }}-kpi-post-install
   labels:
     {{- include "kobo.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "helm.sh/hook-weight": "0"
-    checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
-    checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
-    tag: "{{ .Values.kpi.image.tag }}"
+    "helm.sh/hook-weight": "1"
 spec:
-  activeDeadlineSeconds: {{ default 600 .Values.preInstall.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ default 60 .Values.postInstall.activeDeadlineSeconds }}
   template:
     metadata:
       labels:
@@ -22,10 +19,10 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: pre-install-job
+      - name: post-install-job
         image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag }}"
         imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
-        command: ["./manage.py","migrate"]
+        command: ["/bin/sh", "-c", "{{ .Values.postInstall.command }}"]
         env:
           - name: DJANGO_SECRET_KEY
             value: {{ required "djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}

--- a/templates/kpi/pre-update-job.yaml
+++ b/templates/kpi/pre-update-job.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.preInstall.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "kobo.fullname" . }}-kpi-pre-update
+  labels:
+    {{- include "kobo.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+    checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
+    checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
+    tag: "{{ .Values.kpi.image.tag }}"
+spec:
+  activeDeadlineSeconds: {{ default 600 .Values.preInstall.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: kpi-job
+        {{- include "kobo.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pre-install-job
+        image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag }}"
+        imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
+        command: ["./manage.py","migrate"]
+        env:
+          - name: DJANGO_SECRET_KEY
+            value: {{ required "djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}
+          {{- if .Values.postgresql.enabled }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ default (include "kobo.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+                key: postgres-password
+          - name: DATABASE_URL
+            value: {{ (include "kobo.postgresql.url" .) }}
+          - name: KC_DATABASE_URL
+            value: postgres://postgres:$(POSTGRES_PASSWORD)@{{ (include "kobo.postgresql.fullname" .) }}:5432/postgres
+          {{- else }}
+          - name: DATABASE_URL
+            value: {{ required "kpi.env.secret.DATABASE_URL is a required value." .Values.kpi.env.secret.DATABASE_URL }}
+          - name: KC_DATABASE_URL
+            value: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
+          {{- end }}
+          {{ if .Values.kobotoolbox.redis }}
+          - name: CACHE_URL
+            value: {{ printf "%s/5%s" .Values.kobotoolbox.redis .Values.kobotoolbox.redisParameters | quote }}
+          {{- end }}
+        {{- range $k, $v := .Values.kpi.env.normal }}
+          - name: {{ $k }}
+            value: {{ $v | quote }}
+        {{- end }}
+        {{- with .Values.kpi.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.kpi.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -20,9 +20,14 @@ kobotoolbox:
   #serviceAccountBackend: "redis://:pass@redis-master:6379/6"
   enketoApiKey: "change_me_please"
 
+# Actually post-install and pre-update
 preInstall:
   enabled: true
   activeDeadlineSeconds: 600
+
+postInstall: {}
+  # command: "./manage.py anything"
+  # activeDeadlineSeconds: 60
 
 kpi:
   image:


### PR DESCRIPTION
Adds post-install hook that is disabled by default. It could be used to provision data on install.

TASK-798

# Reviewer notes

The pre-install value is a terrible name as it's not pre-install. I added a note. Changing it would be a bit of a pain, though if we wanted to change it, it will only get more painful the longer we wait.