### PR TITLE
Default redis DB numbers to 0 and 1 TASK-790

### DIFF
--- a/templates/flower/deployment.yaml
+++ b/templates/flower/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "kobo.fullname" . }}-flower
   labels:
     {{- include "kobo.labels" . | nindent 4 }}
-    app.kubernetes.io/component: flower 
+    app.kubernetes.io/component: flower
 spec:
   replicas: 1
   selector:
@@ -55,11 +55,11 @@ spec:
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL
-              value: {{ (include "kobo.redis.url" .) }}/6
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CELERY_BROKER_URL
-              value: {{ (include "kobo.redis.url" .) }}/2
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CACHE_URL
-              value: {{ (include "kobo.redis.url" .) }}/4
+              value: {{ (include "kobo.redis.url" .) }}/1
             {{- end }}
           envFrom:
             - secretRef:

--- a/templates/kpi/deployment-beat.yaml
+++ b/templates/kpi/deployment-beat.yaml
@@ -67,11 +67,11 @@ spec:
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL
-              value: {{ (include "kobo.redis.url" .) }}/6
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CELERY_BROKER_URL
-              value: {{ (include "kobo.redis.url" .) }}/2
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CACHE_URL
-              value: {{ (include "kobo.redis.url" .) }}/4
+              value: {{ (include "kobo.redis.url" .) }}/1
             {{- end }}
           envFrom:
             - secretRef:

--- a/templates/kpi/deployment-worker-kobocat.yaml
+++ b/templates/kpi/deployment-worker-kobocat.yaml
@@ -73,11 +73,11 @@ spec:
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL
-              value: {{ (include "kobo.redis.url" .) }}/6
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CELERY_BROKER_URL
-              value: {{ (include "kobo.redis.url" .) }}/2
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CACHE_URL
-              value: {{ (include "kobo.redis.url" .) }}/4
+              value: {{ (include "kobo.redis.url" .) }}/1
             {{- end }}
           envFrom:
             - secretRef:

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -73,11 +73,11 @@ spec:
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL
-              value: {{ (include "kobo.redis.url" .) }}/6
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CELERY_BROKER_URL
-              value: {{ (include "kobo.redis.url" .) }}/2
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CACHE_URL
-              value: {{ (include "kobo.redis.url" .) }}/4
+              value: {{ (include "kobo.redis.url" .) }}/1
             {{- end }}
           envFrom:
             - secretRef:

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -73,11 +73,11 @@ spec:
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL
-              value: {{ (include "kobo.redis.url" .) }}/6
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CELERY_BROKER_URL
-              value: {{ (include "kobo.redis.url" .) }}/2
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CACHE_URL
-              value: {{ (include "kobo.redis.url" .) }}/4
+              value: {{ (include "kobo.redis.url" .) }}/1
             {{- end }}
           envFrom:
             - secretRef:

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -92,11 +92,11 @@ spec:
             - name: REDIS_SESSION_URL
               value: {{ (include "kobo.redis.url" .) }}/1
             - name: SERVICE_ACCOUNT_BACKEND_URL
-              value: {{ (include "kobo.redis.url" .) }}/6
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CELERY_BROKER_URL
-              value: {{ (include "kobo.redis.url" .) }}/2
+              value: {{ (include "kobo.redis.url" .) }}/1
             - name: CACHE_URL
-              value: {{ (include "kobo.redis.url" .) }}/4
+              value: {{ (include "kobo.redis.url" .) }}/1
             {{- end }}
           envFrom:
             - secretRef:

--- a/values.yaml
+++ b/values.yaml
@@ -9,15 +9,14 @@ kobotoolbox:
   # Redis default DB numbers
   # - Enketo - 0 (cannot be changed)
   # - Session - 1
-  # - KPI Broker - 2
-  # - Kobocat Broker - 3
-  # - KPI Cache - 4
-  # - Kobocat Cache - 5
-  # - Service account - 6
+  # - KPI Broker - 1
+  # - Kobocat Broker - 1
+  # - KPI Cache - 1
+  # - Service account - 1
   #redis: "redis://:pass@redis-master:6379"  # Do not add / nor /1 suffix
   redisParameters: "" # ?ssl_cert_reqs=CERT_REQUIRED
   #redisSession: "redis://:pass@redis-master:6379/1"
-  #serviceAccountBackend: "redis://:pass@redis-master:6379/6"
+  #serviceAccountBackend: "redis://:pass@redis-master:6379/1"
   enketoApiKey: "change_me_please"
 
 # Actually post-install and pre-update
@@ -25,7 +24,8 @@ migrationJob:
   enabled: true
   activeDeadlineSeconds: 600
 
-postInstall: {}
+postInstall:
+  {}
   # command: "./manage.py anything"
   # activeDeadlineSeconds: 60
 
@@ -91,8 +91,8 @@ kpi:
     secret:
       {}
       # DATABASE_URL: "postgres://postgres:password@postgres-postgresql:5432/postgres"
-      # CELERY_BROKER_URL: "redis://localhost:6379/2"
-      # CACHE_URL: "redis://localhost:6379/4"
+      # CELERY_BROKER_URL: "redis://localhost:6379/1"
+      # CACHE_URL: "redis://localhost:6379/1"
       # AWS_ACCESS_KEY_ID: ""
       # AWS_SECRET_ACCESS_KEY: ""
   extraVolumeMounts: []
@@ -156,7 +156,8 @@ kpi:
   ingress:
     enabled: false
     className: ""
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/ingress.class: nginx
     hosts:
       - host: chart-example.local
@@ -172,7 +173,8 @@ kobocat:
   ingress:
     enabled: false
     className: ""
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/ingress.class: nginx
     hosts:
       - host: chart-example.local
@@ -183,7 +185,6 @@ kobocat:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-
 
 flower:
   enabled: false
@@ -201,7 +202,6 @@ flower:
   service:
     type: ClusterIP
     port: 80
-
 
 enketo:
   image:
@@ -245,16 +245,16 @@ enketo:
       # -- Maps settings. It is an array, see https://github.com/enketo/enketo-express/blob/master/config/sample.env#L16-L19
       ENKETO_MAPS_0_NAME: humanitarian
       ENKETO_MAPS_0_TILES_0: "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"
-      ENKETO_MAPS_0_ATTRIBUTION: "&copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> & <a href=\"https://www.hotosm.org/updates/2013-09-29_a_new_window_on_openstreetmap_data\">Yohan Boniface & Humanitarian OpenStreetMap Team</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
+      ENKETO_MAPS_0_ATTRIBUTION: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> & <a href="https://www.hotosm.org/updates/2013-09-29_a_new_window_on_openstreetmap_data">Yohan Boniface & Humanitarian OpenStreetMap Team</a> | <a href="https://www.openstreetmap.org/copyright">Terms</a>'
       ENKETO_MAPS_1_NAME: satellite
       ENKETO_MAPS_1_TILES_0: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
       ENKETO_MAPS_1_ATTRIBUTION: "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
       ENKETO_MAPS_2_NAME: terrain
       ENKETO_MAPS_2_TILES_0: "https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png"
-      ENKETO_MAPS_2_ATTRIBUTION: "&copy; <a href=\"https://openstreetmap.org\">OpenStreetMap</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
+      ENKETO_MAPS_2_ATTRIBUTION: '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> | <a href="https://www.openstreetmap.org/copyright">Terms</a>'
       ENKETO_MAPS_3_NAME: streets
       ENKETO_MAPS_3_TILES_0: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      ENKETO_MAPS_3_ATTRIBUTION: "&copy; <a href=\"https://openstreetmap.org\">OpenStreetMap</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
+      ENKETO_MAPS_3_ATTRIBUTION: '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> | <a href="https://www.openstreetmap.org/copyright">Terms</a>'
       # -- Payload limit
       ENKETO_PAYLOAD_LIMIT: 1mb
       # -- Text field character limit
@@ -298,12 +298,13 @@ enketo:
       # Set if kobotoolbox.redis is unset
       # ENKETO_REDIS_MAIN_URL: "redis://localhost:6379"
       # ENKETO_REDIS_CACHE_URL: "redis://localhost:6379"
-  extraVolumeMounts: [ ]
-  extraVolumes: [ ]
+  extraVolumeMounts: []
+  extraVolumes: []
   ingress:
     enabled: false
     className: ""
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/ingress.class: nginx
     hosts:
       - host: chart-example.local
@@ -413,7 +414,8 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 securityContext:


### PR DESCRIPTION
Consolidate redis DB numbers to just 0 and 1. Simplifies configuration and gets us closer to supporting redis cluster. Since we aren't changing enketo nor sessions - this change should be safe to make without any data migration.