### PR TITLE
Update values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -74,7 +74,8 @@ kpi:
       ENKETO_EXPRESS_PUBLIC_SUBDOMAIN: "ee"
       KOBOCAT_PUBLIC_SUBDOMAIN: "kc"
       KOBOFORM_PUBLIC_SUBDOMAIN: "kobo"
-      PUBLIC_REQUEST_SCHEME: "https"
+      SESSION_COOKIE_DOMAIN: ".kobo.local:8080" # For testing locally, add subdomains to `etc/hosts` (e.g. 127.0.0.1 ee.kobo.local). For production, change this to ".your-domain.tld"
+      PUBLIC_REQUEST_SCHEME: "https" # For testing locally, change this to "http"
       # Celery configuration
       CELERY_WORKER_AUTOSCALE: "2,3"
       CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"


### PR DESCRIPTION
Passed env variable `SESSION_COOKIE_DOMAIN` to fix issue related to CSRF_TRUSTED_ORIGINS

```
Origin checking failed - http://kobo.kobo.local:8080/ does not match any trusted origins.
```

References:
- https://github.com/kobotoolbox/kpi/blob/d802a47a66b1d3faa55bfe6498a02da1a2bfc9bc/kobo/settings/base.py#L56-L65
- https://docs.djangoproject.com/en/5.1/ref/settings/#csrf-trusted-origins