### PR TITLE
Update nginx uswgi timeouts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.13-testing
+version: 4.1.13-testing1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.13
+version: 4.1.13-testing
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.13-testingnginxtpl
+version: 4.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.13-testing1
+version: 4.1.13-testing2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.13-testing2
+version: 4.1.13-testingnginxtpl
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/files/kpi/nginx.conf.tpl
+++ b/files/kpi/nginx.conf.tpl
@@ -8,6 +8,10 @@ server {
     client_max_body_size 100M;
     large_client_header_buffers 8 16k;
 
+    # Set timeout values from Helm values
+    proxy_read_timeout {{ .Values.global.timeout | default 120 }};
+    proxy_send_timeout {{ .Values.global.timeout | default 120 }};
+    
     gzip on;
     gzip_disable "msie6";
     gzip_comp_level 6;

--- a/templates/kpi/configmap.yaml
+++ b/templates/kpi/configmap.yaml
@@ -47,8 +47,5 @@ data:
     {{ .Values.kpi.nginx.config | nindent 4 }}
 {{- else }}
   nginx.conf: |-
-    {{- $nginxConf := .Files.Get "files/kpi/nginx.conf" }}
-    {{- $timeoutDirectives := printf "\n    proxy_read_timeout %d;\n    proxy_send_timeout %d;" (int (.Values.global.timeout | default 120)) (int (.Values.global.timeout | default 120)) }}
-    {{- $modifiedConf := regexReplaceAll "(large_client_header_buffers 8 16k;)" $nginxConf "${1}${timeoutDirectives}" }}
-    {{- $modifiedConf | nindent 4 }}
+    {{- tpl (.Files.Get "files/kpi/nginx.conf.tpl") . | nindent 4 }}
 {{- end }}

--- a/templates/kpi/configmap.yaml
+++ b/templates/kpi/configmap.yaml
@@ -46,5 +46,8 @@ data:
   nginx.conf: |-
     {{ .Values.kpi.nginx.config | nindent 4 }}
 {{- else }}
-{{ (.Files.Glob "files/kpi/nginx.conf").AsConfig | indent 2 }}
-{{- end }}
+  nginx.conf: |-
+    {{- $nginxConf := .Files.Get "files/kpi/nginx.conf" }}
+    {{- $timeoutDirectives := printf "\n    proxy_read_timeout %d;\n    proxy_send_timeout %d;" (int .Values.global.timeout) (int .Values.global.timeout) }}
+    {{- $modifiedConf := regexReplaceAll "(?ms)(large_client_header_buffers.*?;)" $nginxConf "${1}${timeoutDirectives}" }}
+    {{- $modifiedConf | nindent 4 }}

--- a/templates/kpi/configmap.yaml
+++ b/templates/kpi/configmap.yaml
@@ -48,7 +48,7 @@ data:
 {{- else }}
   nginx.conf: |-
     {{- $nginxConf := .Files.Get "files/kpi/nginx.conf" }}
-    {{- $timeoutDirectives := printf "\n    proxy_read_timeout %d;\n    proxy_send_timeout %d;" (int .Values.global.timeout) (int .Values.global.timeout) }}
-    {{- $modifiedConf := regexReplaceAll "(?ms)(large_client_header_buffers.*?;)" $nginxConf "${1}${timeoutDirectives}" }}
+    {{- $timeoutDirectives := printf "\n    proxy_read_timeout %d;\n    proxy_send_timeout %d;" (int (.Values.global.timeout | default 120)) (int (.Values.global.timeout | default 120)) }}
+    {{- $modifiedConf := regexReplaceAll "(large_client_header_buffers 8 16k;)" $nginxConf "${1}${timeoutDirectives}" }}
     {{- $modifiedConf | nindent 4 }}
 {{- end }}

--- a/templates/kpi/configmap.yaml
+++ b/templates/kpi/configmap.yaml
@@ -51,3 +51,4 @@ data:
     {{- $timeoutDirectives := printf "\n    proxy_read_timeout %d;\n    proxy_send_timeout %d;" (int .Values.global.timeout) (int .Values.global.timeout) }}
     {{- $modifiedConf := regexReplaceAll "(?ms)(large_client_header_buffers.*?;)" $nginxConf "${1}${timeoutDirectives}" }}
     {{- $modifiedConf | nindent 4 }}
+{{- end }}

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -98,6 +98,8 @@ spec:
             - name: CACHE_URL
               value: {{ (include "kobo.redis.url" .) }}/4
             {{- end }}
+            - name: UWSGI_HARAKIRI
+              value: "{{ .Values.global.timeout | default 120 }}"               
           envFrom:
             - secretRef:
                 name: {{ include "kobo.fullname" . }}-kpi

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,7 @@
 # Shared, provide your own values here
+global:
+  # Timeout in seconds for both NGINX proxy timeouts and uWSGI harakiri
+  timeout: 120
 kobotoolbox:
   djangoSecret: "change_me_please"
   mongoName: "formhub"


### PR DESCRIPTION
- Converted nginx.conf to nginx.conf.tpl to enable Helm templating (using template variables like {{ .Values.global.timeout }})
- Environment variable for uWSGI: Added the UWSGI_HARAKIRI environment variable to the deployment template, pulling from the same global timeout value
- Added global.timeout to values.yaml with a default of 120 seconds

This ensures UWSGI timeouts and NGINX timeouts are always the same.