### PR TITLE
[INFRA-144] Separate app version and chart version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,7 +16,6 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 5.0.0
-appVersion: "notused"
 
 dependencies:
   - name: mongodb

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,13 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.33
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "2.025.14c"
+version: 5.0.0
+appVersion: "notused"
 
 dependencies:
   - name: mongodb

--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ This chart is still being tested and isn't intended for external use at this tim
 - Every deployment/job should do one thing. Migrate, run uwsgi, run celery, etc
 
 # Usage
+This chart requires a value for `kpi.version` - there is no default set for it.
 
 1. Carefully review values.yaml. Set image tag version, if desired. Set databases, secret keys, etc.
-1. `helm install your-kobo oci://ghcr.io/kobotoolbox/kobo -f your-values.yaml`
+1. `helm install your-kobo oci://ghcr.io/kobotoolbox/kobo -f your-values.yaml --set kpi.version=VERSION_TO_DEPLOY`
 
 ## Upgrading
+This chart requires a value for `kpi.version` - there is no default set for it.
 
 1. `helm repo update`
-1. `helm upgrade your-kobo kobo -f your-values.yaml`
+1. `helm upgrade your-kobo kobo -f your-values.yaml --set kpi.version=VERSION_TO_DEPLOY`
 
 Tip: Consider using helm diff to preview changes first.
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -36,9 +36,7 @@ Common labels
 {{- define "kobo.labels" -}}
 helm.sh/chart: {{ include "kobo.chart" . }}
 {{ include "kobo.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Values.kpi.version | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/templates/enketo/deployment.yaml
+++ b/templates/enketo/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.enketo.image.repository }}:{{ .Values.enketo.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.enketo.image.repository }}:{{ .Values.enketo.image.tag }}"
           imagePullPolicy: {{ .Values.enketo.image.pullPolicy }}
           ports:
             - name: http

--- a/templates/flower/deployment.yaml
+++ b/templates/flower/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
-        tag: "{{ .Values.kpi.image.tag }}"
+        tag: "{{ .Values.kpi.version }}"
         {{- if .Values.flower.podAnnotations }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.flower.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
@@ -34,7 +34,7 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag }}"
+          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.version }}"
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           command: ["celery", "-A", "kobo", "flower"]
           ports:

--- a/templates/kpi/deployment-beat.yaml
+++ b/templates/kpi/deployment-beat.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
-        tag: "{{ .Values.kpi.image.tag }}"
+        tag: "{{ .Values.kpi.version }}"
       labels:
         app.kubernetes.io/component: kpi-beat
         {{- include "kobo.selectorLabels" . | nindent 8 }}
@@ -27,7 +27,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.version }}"
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           resources:
             {{- toYaml .Values.kpi.beat.resources | nindent 12 }}

--- a/templates/kpi/deployment-worker-kobocat.yaml
+++ b/templates/kpi/deployment-worker-kobocat.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
-        tag: "{{ .Values.kpi.image.tag }}"
+        tag: "{{ .Values.kpi.version }}"
       labels:
         app.kubernetes.io/component: kpi-worker-kobocat
         {{- include "kobo.selectorLabels" . | nindent 8 }}
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.version }}"
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           {{- if .Values.kpi.worker.livenessProbe}}
           livenessProbe:

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
-        tag: "{{ .Values.kpi.image.tag }}"
+        tag: "{{ .Values.kpi.version }}"
       labels:
         app.kubernetes.io/component: kpi-worker-low-priority
         {{- include "kobo.selectorLabels" . | nindent 8 }}
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.version }}"
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           {{- if .Values.kpi.workerLowPriority.livenessProbe}}
           livenessProbe:

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
-        tag: "{{ .Values.kpi.image.tag }}"
+        tag: "{{ .Values.kpi.version }}"
       labels:
         app.kubernetes.io/component: kpi-worker
         {{- include "kobo.selectorLabels" . | nindent 8 }}
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.version }}"
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           {{- if .Values.kpi.worker.livenessProbe}}
           livenessProbe:

--- a/templates/kpi/deployment.yaml
+++ b/templates/kpi/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-        tag: "{{ .Values.kpi.image.tag }}"
+        tag: "{{ .Values.kpi.version }}"
         {{- if .Values.kpi.podAnnotations }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.kpi.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
@@ -37,7 +37,7 @@ spec:
         - name: backend
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.kpi.image.repository }}:{{ required "kpi.version required" .Values.kpi.version }}"
           imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
           ports:
             - name: http

--- a/templates/kpi/migration-job.yaml
+++ b/templates/kpi/migration-job.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-weight": "0"
     checksum/secret: {{ include (print $.Template.BasePath "/kpi/secrets.yaml") . | sha256sum }}
     checksum/configmap: {{ include (print $.Template.BasePath "/kpi/configmap.yaml") . | sha256sum }}
-    tag: "{{ .Values.kpi.image.tag }}"
+    tag: "{{ .Values.kpi.version }}"
 spec:
   activeDeadlineSeconds: {{ default 600 .Values.migrationJob.activeDeadlineSeconds }}
   template:
@@ -23,12 +23,12 @@ spec:
       restartPolicy: Never
       containers:
       - name: pre-install-job
-        image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag }}"
+        image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.version }}"
         imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
         command: ["./scripts/migrate.sh"]
         env:
           - name: DJANGO_SECRET_KEY
-            value: {{ required "djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}
+            value: {{ required "kobotoolbox.djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}
           {{- if .Values.postgresql.enabled }}
           - name: POSTGRES_PASSWORD
             valueFrom:
@@ -43,7 +43,7 @@ spec:
           - name: DATABASE_URL
             value: {{ required "kpi.env.secret.DATABASE_URL is a required value." .Values.kpi.env.secret.DATABASE_URL }}
           - name: KC_DATABASE_URL
-            value: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
+            value: {{ required "kobotoolbox.kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
           {{- end }}
           {{ if .Values.kobotoolbox.redis }}
           - name: CACHE_URL

--- a/templates/kpi/post-install-job.yaml
+++ b/templates/kpi/post-install-job.yaml
@@ -20,12 +20,12 @@ spec:
       restartPolicy: Never
       containers:
       - name: post-install-job
-        image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.image.tag }}"
+        image: "{{ .Values.kpi.image.repository }}:{{ .Values.kpi.version }}"
         imagePullPolicy: {{ .Values.kpi.image.pullPolicy }}
         command: ["/bin/sh", "-c", "{{ .Values.postInstall.command }}"]
         env:
           - name: DJANGO_SECRET_KEY
-            value: {{ required "djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}
+            value: {{ required "kobotoolbox.djangoSecret is a required value." .Values.kobotoolbox.djangoSecret }}
           {{- if .Values.postgresql.enabled }}
           - name: POSTGRES_PASSWORD
             valueFrom:
@@ -40,7 +40,7 @@ spec:
           - name: DATABASE_URL
             value: {{ required "kpi.env.secret.DATABASE_URL is a required value." .Values.kpi.env.secret.DATABASE_URL }}
           - name: KC_DATABASE_URL
-            value: {{ required "kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
+            value: {{ required "kobotoolbox.kobocatDatabase required" .Values.kobotoolbox.kobocatDatabase }}
           {{- end }}
           {{ if .Values.kobotoolbox.redis }}
           - name: CACHE_URL

--- a/templates/kpi/secrets.yaml
+++ b/templates/kpi/secrets.yaml
@@ -25,9 +25,9 @@ data:
   SERVICE_ACCOUNT_BACKEND_URL: {{ .Values.kobotoolbox.serviceAccountBackend | b64enc | quote }}
 {{ end }}
 {{ end }}
-  ENKETO_API_KEY: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
+  ENKETO_API_KEY: {{ required "kobotoolbox.enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
   # -- Alias for Enketo API key. Still in used but deprecated
-  ENKETO_API_TOKEN: {{ required "enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
+  ENKETO_API_TOKEN: {{ required "kobotoolbox.enketoApiKey required" .Values.kobotoolbox.enketoApiKey | b64enc | quote }}
 {{- range $k, $v := .Values.kpi.env.secret }}
   {{ $k }}: {{ $v | b64enc | quote }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -36,7 +36,6 @@ kpi:
   image:
     repository: kobotoolbox/kpi
     pullPolicy: IfNotPresent
-    tag: "2.025.14c"
   replicaCount: 1
   resources:
     limits:


### PR DESCRIPTION
This PR increments the helm chart major version to 5.0 and does the following:
* Removes `appVersion`
* Removes the default `kpi.image.tag` from `values.yaml` which in turn requires you set `kpi.version`
* Makes requirement messages a bit more clean

This will allow the chart to be deployed separately of the application.

In order to upgrade to to this version you MUST update your deployments to set `kpi.version` correctly