### PR TITLE
Using bitnamilegacy repository for postgres/mongo/redis

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.2.1
+version: 5.2.2
 
 dependencies:
   - name: mongodb

--- a/values.yaml
+++ b/values.yaml
@@ -334,6 +334,8 @@ nginx:
 # These errors should be rare and brief, minimally acceptable for production.
 mongodb:
   enabled: false
+  image:
+    repository: bitnamilegacy/mongodb
   architecture: "replicaset"
   pdb:
     create: true
@@ -363,6 +365,8 @@ mongodb:
 # Chart managed redis is intended for testing only
 redis:
   enabled: false
+  image:
+    repository: bitnamilegacy/redis
   auth:
     password: "change_me_please"
   commonConfiguration: |-
@@ -392,6 +396,8 @@ redis:
 # Chart managed postgresql is intended for testing only
 postgresql:
   enabled: false
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
     postgresPassword: "change_me_please"
   primary:


### PR DESCRIPTION
The `bitnami` repository no longer contains images due to them being moved.  This updates the repository for postgres/redis/mongo to use the new `bitnamilegacy` repository so that deployment continue to work.   

https://github.com/bitnami/charts/issues/35164#issuecomment-3294431154