### PR TITLE
clery(beat): Allow for configurable scheduler INFRA-446

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.6.0
+version: 5.7.0
 
 dependencies:
   - name: mongodb

--- a/templates/kpi/deployment-beat.yaml
+++ b/templates/kpi/deployment-beat.yaml
@@ -78,7 +78,7 @@ spec:
                 name: {{ include "kobo.fullname" . }}-kpi
             - configMapRef:
                 name: {{ include "kobo.fullname" . }}-kpi
-          command: ["celery", "-A", "kobo", "beat", "-l", "info", "--pidfile=/tmp/celery_beat.pid", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]
+          command: ["celery", "-A", "kobo", "beat", "-l", "info", "--pidfile=/tmp/celery_beat.pid", "--scheduler", "{{ .Values.kpi.beat.scheduler }}"]
           {{- with .Values.kpi.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -162,7 +162,7 @@ kpi:
       targetCPU: 80
       # targetMemory: 80
   beat:
-    scheduler: "kobo.apps.beat.schedulers:ThrottledDatabaseScheduler" # If running a version prior to 2.026.07g this must be overriden to "django_celery_beat.schedulers:DatabaseScheduler"
+    scheduler: "kobo.apps.beat.schedulers:ThrottledDatabaseScheduler" # If running a version prior to 2.026.07g this must be overridden to "django_celery_beat.schedulers:DatabaseScheduler"
     resources:
       limits:
         cpu: 800m

--- a/values.yaml
+++ b/values.yaml
@@ -162,6 +162,7 @@ kpi:
       targetCPU: 80
       # targetMemory: 80
   beat:
+    scheduler: "kobo.apps.beat.schedulers:ThrottledDatabaseScheduler" # If running a version prior to 2.026.07g this must be overriden to "django_celery_beat.schedulers:DatabaseScheduler"
     resources:
       limits:
         cpu: 800m


### PR DESCRIPTION
This adds a new value `kpi.beat.scheduler` that defaults to `kobo.apps.beat.schedulers:ThrottledDatabaseScheduler` which was released in 2.026.07g.  If using a version prior to 2.026.07g, you must override the value as annotated in the comment.