### PR TITLE
enketo(version):Remove default enketo version INFRA-439

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Verify helm chart is valid
         id: helm-lint
         run: |
-          helm lint --strict --set kpi.env.secret.DATABASE_URL=test --set kobotoolbox.kobocatDatabase=test --set kpi.version=test
+          helm lint --strict --set kpi.env.secret.DATABASE_URL=test --set kobotoolbox.kobocatDatabase=test --set kpi.version=test --set enketo.version=test
       
       - name: Failure messages
         if: failure()

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.7.0
+version: 5.8.0
 
 dependencies:
   - name: mongodb

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ This chart is still being tested and isn't intended for external use at this tim
 - Every deployment/job should do one thing. Migrate, run uwsgi, run celery, etc
 
 # Usage
-This chart requires a value for `kpi.version` - there is no default set for it.
+This chart requires values for `kpi.version` and `enketo.version` - there are no defaults set for them.
 
 1. Carefully review values.yaml. Set image tag version, if desired. Set databases, secret keys, etc.
-1. `helm install your-kobo oci://ghcr.io/kobotoolbox/kobo -f your-values.yaml --set kpi.version=VERSION_TO_DEPLOY`
+1. `helm install your-kobo oci://ghcr.io/kobotoolbox/kobo -f your-values.yaml --set kpi.version=VERSION_TO_DEPLOY --set enketo.version=VERSION_TO_DEPLOY`
 
 ## Upgrading
-This chart requires a value for `kpi.version` - there is no default set for it.
+This chart requires values for `kpi.version` and `enketo.version` - there are no defaults set for them.
 
 1. `helm repo update`
-1. `helm upgrade your-kobo kobo -f your-values.yaml --set kpi.version=VERSION_TO_DEPLOY`
+1. `helm upgrade your-kobo kobo -f your-values.yaml --set kpi.version=VERSION_TO_DEPLOY --set enketo.version=VERSION_TO_DEPLOY`
 
 Tip: Consider using helm diff to preview changes first.
 

--- a/templates/enketo/deployment.yaml
+++ b/templates/enketo/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/enketo/secrets.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/enketo/configmap.yaml") . | sha256sum }}
-        tag: "{{ .Values.enketo.image.tag }}"
+        tag: "{{ .Values.enketo.version }}"
       labels:
         app.kubernetes.io/component: enketo
         {{- include "kobo.selectorLabels" . | nindent 8 }}
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.enketo.image.repository }}:{{ .Values.enketo.image.tag }}"
+          image: "{{ .Values.enketo.image.repository }}:{{ required "enketo.version required" .Values.enketo.version }}"
           imagePullPolicy: {{ .Values.enketo.image.pullPolicy }}
           ports:
             - name: http

--- a/values.yaml
+++ b/values.yaml
@@ -234,7 +234,6 @@ enketo:
   image:
     repository: kobotoolbox/enketo-express-extra-widgets
     pullPolicy: IfNotPresent
-    tag: "7.6.1"
   replicaCount: 1
   resources:
     limits:


### PR DESCRIPTION
- remove the default enketo version in the helm chart and require it as an input