### PR TITLE
logs(nginx): Add x-kobonaut header to nginx logging INFRA-468

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.9.0
+version: 5.9.1
 
 dependencies:
   - name: mongodb

--- a/files/kpi/nginx.conf.tpl
+++ b/files/kpi/nginx.conf.tpl
@@ -26,6 +26,7 @@ server {
 
     client_max_body_size 100M;
     large_client_header_buffers 8 16k;
+    access_log  /var/log/nginx/access.log with_host;
 
     {{ if .Values.kpi.nginx.large_headers.enabled -}}
     # Proxy buffer settings to handle large headers


### PR DESCRIPTION
This adds the `x-kobonaut` header to the nginx logging.  While the logging format had it, the line that told nginx to use the logging format was missing so this resolves that.