### PR TITLE
chore(misc): Add service accounts to all deployments INFRA-344

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.0
+version: 6.0.1
 
 dependencies:
   - name: mongodb

--- a/templates/kpi/deployment-beat.yaml
+++ b/templates/kpi/deployment-beat.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/component: kpi-beat
         {{- include "kobo.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "kobo.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/templates/kpi/deployment-worker-kobocat.yaml
+++ b/templates/kpi/deployment-worker-kobocat.yaml
@@ -23,6 +23,7 @@ spec:
         app.kubernetes.io/component: kpi-worker-kobocat
         {{- include "kobo.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "kobo.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/templates/kpi/deployment-worker-long-running.yaml
+++ b/templates/kpi/deployment-worker-long-running.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/component: kpi-worker-long-running
         {{- include "kobo.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "kobo.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/templates/kpi/deployment-worker-low-priority.yaml
+++ b/templates/kpi/deployment-worker-low-priority.yaml
@@ -23,6 +23,7 @@ spec:
         app.kubernetes.io/component: kpi-worker-low-priority
         {{- include "kobo.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "kobo.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/templates/kpi/deployment-worker.yaml
+++ b/templates/kpi/deployment-worker.yaml
@@ -23,6 +23,7 @@ spec:
         app.kubernetes.io/component: kpi-worker
         {{- include "kobo.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "kobo.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:


### PR DESCRIPTION
This adds the `serviceAccountName` to all deployments so that they can use EKS pod identities in the future